### PR TITLE
allow empty password

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,3 +82,6 @@ jobs:
         uses: ./
         with:
           mysql-version: ${{ matrix.mysql }}
+      - name: connect to MySQL server
+        run: |
+          mysql -uroot -e 'SELECT version()'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,4 +84,4 @@ jobs:
           mysql-version: ${{ matrix.mysql }}
       - name: connect to MySQL server
         run: |
-          mysql -h127.0.0.1 -uroot -e 'SELECT version()'
+          mysql --host=127.0.0.1 --user=root -e 'SELECT version()'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,4 +84,4 @@ jobs:
           mysql-version: ${{ matrix.mysql }}
       - name: connect to MySQL server
         run: |
-          mysql -uroot -e 'SELECT version()'
+          mysql -h127.0.0.1 -uroot -e 'SELECT version()'

--- a/src/starter.ts
+++ b/src/starter.ts
@@ -216,7 +216,7 @@ async function installDbHelp(mysql: installer.MySQL): Promise<string> {
   }
   try {
     await exec.exec(
-      path.join(mysql.toolPath, 'script', 'mysql_install_db'),
+      path.join(mysql.toolPath, 'scripts', 'mysql_install_db'),
       ['--help'],
       options
     )

--- a/src/starter.ts
+++ b/src/starter.ts
@@ -221,9 +221,8 @@ async function installDbHelp(mysql: installer.MySQL): Promise<string> {
       options
     )
   } catch (e) {
-    core.error('mysql_install_db')
-    core.error(myOutput)
-    throw e
+    // suppress the exception.
+    // "mysql_install_db --help" returns exit code 1.
   }
   return myOutput
 }

--- a/src/starter.ts
+++ b/src/starter.ts
@@ -84,10 +84,17 @@ export async function startMySQL(
       fs.existsSync(path.join(mysql.toolPath, 'bin', 'mariadb-install-db.exe'))
     ) {
       // MariaDB on Windows has mariadb-install-db.exe utility
-      // that is the Windows equivalent of mysql_install_db.
+      // that is the Windows equivalent of mysql_install_db.exe
       // https://mariadb.com/kb/en/mysql_install_dbexe/
       await exec.exec(
         path.join(mysql.toolPath, 'bin', 'mariadb-install-db.exe'),
+        [`--datadir=${baseDir}${sep}var`]
+      )
+    } else if (fs.existsSync(path.join(mysql.toolPath, 'bin', 'mysql_install_db.exe'))) {
+      // mysql_install_db.exe is old name of mariadb-install-db.exe
+      // https://mariadb.com/kb/en/mariadb-install-db/
+      await exec.exec(
+        path.join(mysql.toolPath, 'bin', 'mysql_install_db.exe'),
         [`--datadir=${baseDir}${sep}var`]
       )
     } else if (useMysqldInitialize) {

--- a/src/starter.ts
+++ b/src/starter.ts
@@ -126,10 +126,7 @@ export async function startMySQL(
         // We set "normal" to revert to the previous authentication method.
         installArgs.push('--auth-root-authentication-method=normal')
       }
-      await exec.exec(
-        path.join(mysql.toolPath, 'scripts', 'mysql_install_db'),
-        installArgs
-      )
+      await exec.exec(command, installArgs)
     }
   })
 


### PR DESCRIPTION
For security reason, newer versions of MySQL and MariaDB disable empty password by default.
I want to use empty password because the action is only for testing.
