### PR TITLE
disable parallel build on windows

### DIFF
--- a/.github/build-mysql-windows.ps1
+++ b/.github/build-mysql-windows.ps1
@@ -110,9 +110,7 @@ cmake ( Join-Path $RUNNER_TEMP "mysql-server-mysql-$MYSQL_VERSION" ) `
     -DDOWNLOAD_BOOST=1 -DWITH_BOOST="$BOOST" `
     -DCMAKE_INSTALL_PREFIX="$PREFIX" `
     -DWITH_SSL="$PREFIX" `
-    -DCMAKE_BUILD_TYPE=MinSizeRel `
-    -DCMAKE_CXX_FLAGS="/MP1" `
-    -DCMAKE_C_FLAGS="/MP1"
+    -DCMAKE_BUILD_TYPE=MinSizeRel
 
 devenv MySQL.sln /build RelWithDebInfo
 Write-Host "::endgroup::"

--- a/.github/build-mysql-windows.ps1
+++ b/.github/build-mysql-windows.ps1
@@ -110,7 +110,9 @@ cmake ( Join-Path $RUNNER_TEMP "mysql-server-mysql-$MYSQL_VERSION" ) `
     -DDOWNLOAD_BOOST=1 -DWITH_BOOST="$BOOST" `
     -DCMAKE_INSTALL_PREFIX="$PREFIX" `
     -DWITH_SSL="$PREFIX" `
-    -DCMAKE_BUILD_TYPE=MinSizeRel
+    -DCMAKE_BUILD_TYPE=MinSizeRel `
+    -DCMAKE_CXX_FLAGS="/MP1" `
+    -DCMAKE_C_FLAGS="/MP1"
 
 devenv MySQL.sln /build RelWithDebInfo
 Write-Host "::endgroup::"

--- a/patches/mysql/8.0.26/disable-multiprocessor-build.patch
+++ b/patches/mysql/8.0.26/disable-multiprocessor-build.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/os/Windows.cmake b/cmake/os/Windows.cmake
+index 6267faf2335..0bc4b7e5eea 100644
+--- a/cmake/os/Windows.cmake
++++ b/cmake/os/Windows.cmake
+@@ -185,9 +185,9 @@ IF(MSVC)
+   ENDFOREACH()
+ 
+   IF(NOT WIN32_CLANG)
+-    # Speed up multiprocessor build (not supported by the Clang driver)
+-    STRING_APPEND(CMAKE_C_FLAGS " /MP")
+-    STRING_APPEND(CMAKE_CXX_FLAGS " /MP")
++    # disable multiprocessor build (not supported by the Clang driver)
++    STRING_APPEND(CMAKE_C_FLAGS " /MP1")
++    STRING_APPEND(CMAKE_CXX_FLAGS " /MP1")
+   ENDIF()
+ 
+   #TODO: update the code and remove the disabled warnings


### PR DESCRIPTION
because build fails with out of memory