### PR TITLE
build Release

### DIFF
--- a/.github/build-mysql-windows.ps1
+++ b/.github/build-mysql-windows.ps1
@@ -110,15 +110,15 @@ cmake ( Join-Path $RUNNER_TEMP "mysql-server-mysql-$MYSQL_VERSION" ) `
     -DDOWNLOAD_BOOST=1 -DWITH_BOOST="$BOOST" `
     -DCMAKE_INSTALL_PREFIX="$PREFIX" `
     -DWITH_SSL="$PREFIX" `
-    -DCMAKE_BUILD_TYPE=MinSizeRel
+    -DCMAKE_BUILD_TYPE=Release
 
-devenv MySQL.sln /build RelWithDebInfo
+devenv MySQL.sln /build Release
 Write-Host "::endgroup::"
 
 Write-Host "::group::install"
 Set-Location "$RUNNER_TEMP\build"
-devenv MySQL.sln /build RelWithDebInfo /project initial_database
-devenv MySQL.sln /build RelWithDebInfo /project package
+devenv MySQL.sln /build Release /project initial_database
+devenv MySQL.sln /build Release /project package
 Write-Host "::endgroup::"
 
 

--- a/patches/mysql/5.6.51/skip-install-pdb.patch
+++ b/patches/mysql/5.6.51/skip-install-pdb.patch
@@ -1,0 +1,74 @@
+diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
+index 74ca5793e98..75a1e402489 100644
+--- a/cmake/install_macros.cmake
++++ b/cmake/install_macros.cmake
+@@ -23,42 +23,8 @@
+ GET_FILENAME_COMPONENT(MYSQL_CMAKE_SCRIPT_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
+ INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/cmake_parse_arguments.cmake)
+ MACRO (INSTALL_DEBUG_SYMBOLS targets)
+-  IF(MSVC)
+-  FOREACH(target ${targets})
+-    GET_TARGET_PROPERTY(location ${target} LOCATION)
+-    GET_TARGET_PROPERTY(type ${target} TYPE)
+-    IF(NOT INSTALL_LOCATION)
+-      IF(type MATCHES "STATIC_LIBRARY"
+-          OR type MATCHES "MODULE_LIBRARY"
+-          OR type MATCHES "SHARED_LIBRARY")
+-        SET(INSTALL_LOCATION "lib")
+-      ELSEIF(type MATCHES "EXECUTABLE")
+-        SET(INSTALL_LOCATION "bin")
+-      ELSE()
+-        MESSAGE(FATAL_ERROR
+-          "cannot determine type of ${target}. Don't now where to install")
+-     ENDIF()
+-    ENDIF()
+-    STRING(REPLACE ".exe" ".pdb" pdb_location ${location})
+-    STRING(REPLACE ".dll" ".pdb" pdb_location ${pdb_location})
+-    STRING(REPLACE ".lib" ".pdb" pdb_location ${pdb_location})
+-    IF(CMAKE_GENERATOR MATCHES "Visual Studio")
+-      STRING(REPLACE
+-        "${CMAKE_CFG_INTDIR}" "\${CMAKE_INSTALL_CONFIG_NAME}"
+-        pdb_location ${pdb_location})
+-    ENDIF()
+-    IF(target STREQUAL "mysqld")
+-	  SET(comp Server)
+-    ELSE()
+-      SET(comp Debuginfo)
+-    ENDIF()	  
+-    # No .pdb file for static libraries.
+-    IF(NOT type MATCHES "STATIC_LIBRARY")
+-      INSTALL(FILES ${pdb_location}
+-        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
+-    ENDIF()
+-  ENDFOREACH()
+-  ENDIF()
++# .pdb files are too large to use in GitHub Actions.
++# so skip intalling
+ ENDMACRO()
+ 
+ # Installs manpage for given file (either script or executable)
+@@ -269,24 +235,5 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
+     COMPONENT ${ARG_COMPONENT}
+     OPTIONAL)
+ 
+-  IF(MSVC)
+-    GET_FILENAME_COMPONENT(ext ${debug_target_location} EXT)
+-    STRING(REPLACE "${ext}" ".pdb"  debug_pdb_target_location "${debug_target_location}" )
+-    IF (RENAME_PARAM)
+-      IF(NOT ARG_PDB_DESTINATION)
+-        STRING(REPLACE "${ext}" ".pdb"  "${ARG_RENAME}" pdb_rename)
+-        SET(PDB_RENAME_PARAM RENAME "${pdb_rename}")
+-      ENDIF()
+-    ENDIF()
+-    IF(NOT ARG_PDB_DESTINATION)
+-      SET(ARG_PDB_DESTINATION "${ARG_DESTINATION}")
+-    ENDIF()
+-    INSTALL(FILES ${debug_pdb_target_location}
+-      DESTINATION ${ARG_PDB_DESTINATION}
+-      ${PDB_RENAME_PARAM}
+-      CONFIGURATIONS Release RelWithDebInfo
+-      COMPONENT ${ARG_COMPONENT}
+-      OPTIONAL)
+-  ENDIF()
+ ENDFUNCTION()
+ 

--- a/patches/mysql/5.7.35/skip-install-pdb.patch
+++ b/patches/mysql/5.7.35/skip-install-pdb.patch
@@ -1,0 +1,65 @@
+diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
+index d2eea7df106..58cc99a31f7 100644
+--- a/cmake/install_macros.cmake
++++ b/cmake/install_macros.cmake
+@@ -25,35 +25,8 @@ INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/cmake_parse_arguments.cmake)
+ 
+ # For windows: install .pdf file for each target.
+ MACRO (INSTALL_DEBUG_SYMBOLS targets)
+-  IF(MSVC)
+-  FOREACH(target ${targets})
+-    GET_TARGET_PROPERTY(type ${target} TYPE)
+-    IF(NOT INSTALL_LOCATION)
+-      IF(type MATCHES "STATIC_LIBRARY"
+-          OR type MATCHES "MODULE_LIBRARY"
+-          OR type MATCHES "SHARED_LIBRARY")
+-        SET(INSTALL_LOCATION "lib")
+-      ELSEIF(type MATCHES "EXECUTABLE")
+-        SET(INSTALL_LOCATION "bin")
+-      ELSE()
+-        MESSAGE(FATAL_ERROR
+-          "cannot determine type of ${target}. Don't now where to install")
+-     ENDIF()
+-    ENDIF()
+-
+-    IF(target STREQUAL "mysqld")
+-      SET(comp Server)
+-    ELSE()
+-      SET(comp Debuginfo)
+-    ENDIF()
+-
+-    # No .pdb file for static libraries.
+-    IF(NOT type MATCHES "STATIC_LIBRARY")
+-      INSTALL(FILES $<TARGET_PDB_FILE:${target}>
+-        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
+-    ENDIF()
+-  ENDFOREACH()
+-  ENDIF()
++# .pdb files are too large to use in GitHub Actions.
++# so skip intalling
+ ENDMACRO()
+ 
+ 
+@@ -259,22 +232,5 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
+     COMPONENT ${ARG_COMPONENT}
+     OPTIONAL)
+ 
+-  # For windows, install .pdb files for .exe and .dll files.
+-  IF(MSVC AND NOT target_type STREQUAL "STATIC_LIBRARY")
+-    GET_FILENAME_COMPONENT(ext ${debug_target_location} EXT)
+-    STRING(REPLACE "${ext}" ".pdb"
+-      debug_pdb_target_location "${debug_target_location}" )
+-    IF (RENAME_PARAM)
+-      STRING(REPLACE "${ext}" ".pdb"  pdb_rename "${ARG_RENAME}")
+-      SET(PDB_RENAME_PARAM RENAME "${pdb_rename}")
+-    ENDIF()
+-
+-    INSTALL(FILES ${debug_pdb_target_location}
+-      DESTINATION ${ARG_DESTINATION}
+-      ${PDB_RENAME_PARAM}
+-      CONFIGURATIONS Release RelWithDebInfo
+-      COMPONENT ${ARG_COMPONENT}
+-      OPTIONAL)
+-  ENDIF()
+ ENDFUNCTION()
+ 

--- a/patches/mysql/8.0.26/skip-install-pdb.patch
+++ b/patches/mysql/8.0.26/skip-install-pdb.patch
@@ -62,3 +62,17 @@ index 206dea179a2..262a068c871 100644
  ENDFUNCTION()
  
  
+diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
+index 89d0f36ae73..5491b475f86 100644
+--- a/router/cmake/Plugin.cmake
++++ b/router/cmake/Plugin.cmake
+@@ -150,9 +150,6 @@ FUNCTION(add_harness_plugin NAME)
+       INSTALL(TARGETS ${NAME}
+         RUNTIME DESTINATION ${_option_DESTINATION}
+         COMPONENT Router)
+-      INSTALL(FILES $<TARGET_PDB_FILE:${NAME}>
+-        DESTINATION ${_option_DESTINATION}
+-        COMPONENT Router)
+     ELSE()
+       INSTALL(TARGETS ${NAME}
+         LIBRARY DESTINATION ${_option_DESTINATION}

--- a/patches/mysql/8.0.26/skip-install-pdb.patch
+++ b/patches/mysql/8.0.26/skip-install-pdb.patch
@@ -1,0 +1,64 @@
+diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
+index 206dea179a2..262a068c871 100644
+--- a/cmake/install_macros.cmake
++++ b/cmake/install_macros.cmake
+@@ -22,33 +22,8 @@
+ 
+ # For windows: install .pdb file for each target.
+ MACRO(INSTALL_DEBUG_SYMBOLS target)
+-  IF(MSVC)
+-    GET_TARGET_PROPERTY(type ${target} TYPE)
+-    IF(NOT INSTALL_LOCATION)
+-      IF(type MATCHES "STATIC_LIBRARY"
+-          OR type MATCHES "MODULE_LIBRARY"
+-          OR type MATCHES "SHARED_LIBRARY")
+-        SET(INSTALL_LOCATION "lib")
+-      ELSEIF(type MATCHES "EXECUTABLE")
+-        SET(INSTALL_LOCATION "bin")
+-      ELSE()
+-        MESSAGE(FATAL_ERROR
+-          "cannot determine type of ${target}. Don't now where to install")
+-     ENDIF()
+-    ENDIF()
+-
+-    IF(target STREQUAL "mysqld" OR target STREQUAL "mysqlbackup")
+-      SET(comp Server)
+-    ELSE()
+-      SET(comp Debuginfo)
+-    ENDIF()
+-
+-    # No .pdb file for static libraries.
+-    IF(NOT type MATCHES "STATIC_LIBRARY")
+-      INSTALL(FILES $<TARGET_PDB_FILE:${target}>
+-        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
+-    ENDIF()
+-  ENDIF()
++# .pdb files are too large to use in GitHub Actions.
++# so skip intalling
+ ENDMACRO()
+ 
+ 
+@@ -254,23 +229,6 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
+     COMPONENT ${ARG_COMPONENT}
+     OPTIONAL)
+ 
+-  # For windows, install .pdb files for .exe and .dll files.
+-  IF(MSVC AND NOT target_type STREQUAL "STATIC_LIBRARY")
+-    GET_FILENAME_COMPONENT(ext ${debug_target_location} EXT)
+-    STRING(REPLACE "${ext}" ".pdb"
+-      debug_pdb_target_location "${debug_target_location}" )
+-    IF (RENAME_PARAM)
+-      STRING(REPLACE "${ext}" ".pdb"  pdb_rename "${ARG_RENAME}")
+-      SET(PDB_RENAME_PARAM RENAME "${pdb_rename}")
+-    ENDIF()
+-
+-    INSTALL(FILES ${debug_pdb_target_location}
+-      DESTINATION ${ARG_DESTINATION}
+-      ${PDB_RENAME_PARAM}
+-      CONFIGURATIONS Release RelWithDebInfo
+-      COMPONENT ${ARG_COMPONENT}
+-      OPTIONAL)
+-  ENDIF()
+ ENDFUNCTION()
+ 
+ 


### PR DESCRIPTION
we have out of memory problem on windows.
https://github.com/shogo82148/actions-setup-mysql/runs/3153562557?check_suite_focus=true

```
  20>------ Build started: Project: configure_mysql_router_extra, Configuration: RelWithDebInfo x64 ------
  21>------ Build started: Project: sql_main, Configuration: RelWithDebInfo x64 ------
  21>sql_yacc.cc
  21>sql_hints.yy.cc
  21>C:\Temp\build\sql\sql_hints.yy.cc(1438,5): warning C4065: switch statement contains 'default' but no 'case' labels
  21>sql_digest.cc
  21>sql_lex.cc
  21>sql_lex_hash.cc
  21>sql_lex_hints.cc
  21>Generating Code...
  21>sql_main.vcxproj -> C:\Temp\build\sql\RelWithDebInfo\sql_main.lib
  21>Done building project "sql_main.vcxproj".
  22>------ Build started: Project: GenMysqldDef, Configuration: RelWithDebInfo x64 ------
  23>------ Build started: Project: server_unittest_library, Configuration: RelWithDebInfo x64 ------
  23>Generating server_unittest_library.c
  22>Creating def file...
  22>Generating RelWithDebInfo/mysqld.def
  22>Creating def file finished in 3.48s. (We used 0.203s, link used 3.44s CPU time)
  23>server_unittest_library.c
  23>server_unittest_library.vcxproj -> C:\Temp\build\RelWithDebInfo\server_unittest_library.lib
  24>------ Build started: Project: mysqld, Configuration: RelWithDebInfo x64 ------
  25>------ Build started: Project: merge_component_keyring_common_tests-t, Configuration: RelWithDebInfo x64 ------
  24>   Creating library C:/Temp/build/sql/RelWithDebInfo/mysqld.lib and object C:/Temp/build/sql/RelWithDebInfo/mysqld.exp
  25>   Creating library C:/Temp/build/unittest/gunit/components/keyring_common/RelWithDebInfo/merge_component_keyring_common_tests-t.lib and object C:/Temp/build/unittest/gunit/components/keyring_common/RelWithDebInfo/merge_component_keyring_common_tests-t.exp
  24>mysqld.vcxproj -> C:\Temp\build\runtime_output_directory\RelWithDebInfo\mysqld.exe
  26>------ Build started: Project: merge_innodb_tests-t, Configuration: RelWithDebInfo x64 ------
  26>   Creating library C:/Temp/build/unittest/gunit/innodb/RelWithDebInfo/merge_innodb_tests-t.lib and object C:/Temp/build/unittest/gunit/innodb/RelWithDebInfo/merge_innodb_tests-t.exp
  26>merge_innodb_tests-t.vcxproj -> C:\Temp\build\runtime_output_directory\RelWithDebInfo\merge_innodb_tests-t.exe
  25>merge_component_keyring_common_tests-t.vcxproj -> C:\Temp\build\runtime_output_directory\RelWithDebInfo\merge_component_keyring_common_tests-t.exe
  27>------ Build started: Project: merge_keyring_file_tests-t, Configuration: RelWithDebInfo x64 ------
  28>------ Build started: Project: minimal_chassis_test_driver-t, Configuration: RelWithDebInfo x64 ------
  27>LINK : fatal error LNK1102: out of memory
  28>LINK : fatal error LNK1102: out of memory
  28>Done building project "minimal_chassis_test_driver-t.vcxproj" -- FAILED.
  29>------ Build started: Project: merge_temptable_tests-t, Configuration: RelWithDebInfo x64 ------
  27>Done building project "merge_keyring_file_tests-t.vcxproj" -- FAILED.
  30>------ Build started: Project: merge_large_tests-t, Configuration: RelWithDebInfo x64 ------
  29>   Creating library C:/Temp/build/unittest/gunit/temptable/RelWithDebInfo/merge_temptable_tests-t.lib and object C:/Temp/build/unittest/gunit/temptable/RelWithDebInfo/merge_temptable_tests-t.exp
  30>   Creating library C:/Temp/build/unittest/gunit/RelWithDebInfo/merge_large_tests-t.lib and object C:/Temp/build/unittest/gunit/RelWithDebInfo/merge_large_tests-t.exp
  29>merge_temptable_tests-t.vcxproj -> C:\Temp\build\runtime_output_directory\RelWithDebInfo\merge_temptable_tests-t.exe
  31>------ Build started: Project: pfs_connect_attr-t, Configuration: RelWithDebInfo x64 ------
  31>LINK : fatal error LNK1102: out of memory
  31>Done building project "pfs_connect_attr-t.vcxproj" -- FAILED.
  32>------ Build started: Project: reference_cache-t, Configuration: RelWithDebInfo x64 ------
  32>LINK : fatal error LNK1102: out of memory
  32>Done building project "reference_cache-t.vcxproj" -- FAILED.
  30>merge_large_tests-t.vcxproj -> C:\Temp\build\runtime_output_directory\RelWithDebInfo\merge_large_tests-t.exe
  33>------ Build started: Project: PACKAGE, Configuration: RelWithDebInfo x64 ------
  33>CPack: Create package using ZIP
  33>CPack: Install projects
  33>CPack: - Install project: MySQL [RelWithDebInfo]
  33>CPack: Create package
  33>CPack: - package: C:/Temp/build/mysql-8.0.26-winx64.zip generated.
  ========== Build: 29 succeeded, 4 failed, 507 up-to-date, 0 skipped ==========
```

I guess it is due to generate debug information (.pdb) files.
so, stop generating them.