### PR TITLE
GitHub-hosted runner macOS 11 is now GA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-18.04
-          - macos-11.0
+          - macos-11
           - macos-10.15
           - windows-2019
         mysql:


### PR DESCRIPTION
https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/