### PR TITLE
drop support for macOS 10.15

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -56,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   build-darwin:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -56,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   build-darwin:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
           - ubuntu-18.04
           - macos-12
           - macos-11
-          - macos-10.15
           - windows-2022
           - windows-2019
         mysql:


### PR DESCRIPTION
- https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
- https://github.com/actions/virtual-environments/issues/5583