### PR TITLE
Removed set-output warnings in CI

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -23,9 +23,9 @@ jobs:
           if [[ -z "$MARIADB_VERSIONS" ]]; then
             export MARIADB_VERSIONS=$(< versions/mariadb.json)
           fi
-          echo "::set-output name=matrix-linux::$(printenv MARIADB_VERSIONS | jq -c '{mariadb: . , os: ["ubuntu-20.04", "ubuntu-22.04"]}')"
-          echo "::set-output name=matrix-darwin::$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')"
-          echo "::set-output name=matrix-windows::$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')"
+          echo "matrix-linux=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: . , os: ["ubuntu-20.04", "ubuntu-22.04"]}')" >> $GITHUB_OUTPUT
+          echo "matrix-darwin=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')" >> $GITHUB_OUTPUT
+          echo "matrix-windows=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')" >> $GITHUB_OUTPUT
         env:
           MARIADB_VERSIONS: ${{ github.event.inputs.mariadb-versions }}
     outputs:

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -23,9 +23,9 @@ jobs:
           if [[ -z "$MYSQL_VERSIONS" ]]; then
             export MYSQL_VERSIONS=$(< versions/mysql.json)
           fi
-          echo "::set-output name=matrix-linux::$(printenv MYSQL_VERSIONS | jq -c '{mysql: . , os: ["ubuntu-20.04", "ubuntu-22.04"]}')"
-          echo "::set-output name=matrix-darwin::$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')"
-          echo "::set-output name=matrix-windows::$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')"
+          echo "matrix-linux=$(printenv MYSQL_VERSIONS | jq -c '{mysql: . , os: ["ubuntu-20.04", "ubuntu-22.04"]}')" >> $GITHUB_OUTPUT
+          echo "matrix-darwin=$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')" >> $GITHUB_OUTPUT
+          echo "matrix-windows=$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')" >> $GITHUB_OUTPUT
         env:
           MYSQL_VERSIONS: ${{ github.event.inputs.mysql-versions }}
     outputs:


### PR DESCRIPTION
My CI pipelines was showing warnings related to the [deprecated use of set-output and set-state](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), so I wanted to send you a PR to remove those warnings.

It turns out those warnings were generated by @actions/core 1.9.1, and dependabot already upgraded to @actions/core 1.10.0, but you haven't released a new actions-setup-mysql version since.

Anyway, I found some occurrences of the deprecated usage in this repo workflow files (that are unrelated to my initial problem, but still worth fixing ;) )