### PR TITLE
fix dependabot config errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
         update-types: ["version-update:semver-patch"]
     groups:
       typescript-eslint:
-        pattern:
+        patterns:
           - "@typescript-eslint/*"
 
   # Maintain dependencies for GitHub Actions


### PR DESCRIPTION
```
The property '#/updates/0/groups/typescript-eslint' did not contain a required property of 'patterns'
The property '#/updates/0/groups/typescript-eslint' contains additional properties ["pattern"] outside of the schema when none are allowed
```