### PR TITLE
fix broken build of MariaDB

### DIFF
--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -135,7 +135,7 @@ echo "::group::build MariaDB"
         -DWITH_UNIT_TESTS=OFF \
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DWITH_SSL="$PREFIX" -DPLUGIN_TOKUDB=NO \
-        -DWITH_PCRE=bundled
+        -DWITH_PCRE=bundled -DWITH_ZLIB=bundled
     make "-j$JOBS"
 )
 echo "::endgroup::"

--- a/patches/mariadb/10.4.34/find-libs.patch
+++ b/patches/mariadb/10.4.34/find-libs.patch
@@ -1,0 +1,205 @@
+diff --git a/cmake/FindLZ4.cmake b/cmake/FindLZ4.cmake
+index 46c1fdc1b9f..48a7790afcd 100644
+--- a/cmake/FindLZ4.cmake
++++ b/cmake/FindLZ4.cmake
+@@ -1,9 +1,9 @@
+-find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
++find_path(LZ4_INCLUDE_DIRS NAMES lz4.h)
+ find_library(LZ4_LIBRARIES NAMES lz4)
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     LZ4 DEFAULT_MSG
+-    LZ4_LIBRARIES LZ4_INCLUDE_DIR)
++    LZ4_LIBRARIES LZ4_INCLUDE_DIRS)
+ 
+-mark_as_advanced(LZ4_INCLUDE_DIR LZ4_LIBRARIES)
++mark_as_advanced(LZ4_INCLUDE_DIRS LZ4_LIBRARIES)
+diff --git a/cmake/FindLZO.cmake b/cmake/FindLZO.cmake
+new file mode 100644
+index 00000000000..04391bb4720
+--- /dev/null
++++ b/cmake/FindLZO.cmake
+@@ -0,0 +1,9 @@
++find_path(LZO_INCLUDE_DIRS NAMES lzo/lzo1x.h)
++find_library(LZO_LIBRARIES NAMES lzo2)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    LZO DEFAULT_MSG
++    LZO_LIBRARIES LZO_INCLUDE_DIRS)
++
++mark_as_advanced(LZO_INCLUDE_DIRS LZO_LIBRARIES)
+diff --git a/cmake/FindSnappy.cmake b/cmake/FindSnappy.cmake
+new file mode 100644
+index 00000000000..1e99eb65a50
+--- /dev/null
++++ b/cmake/FindSnappy.cmake
+@@ -0,0 +1,9 @@
++find_path(SNAPPY_INCLUDE_DIRS NAMES snappy.h)
++find_library(SNAPPY_LIBRARIES NAMES snappy)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    Snappy DEFAULT_MSG
++    SNAPPY_LIBRARIES SNAPPY_INCLUDE_DIRS)
++
++mark_as_advanced(SNAPPY_INCLUDE_DIRS SNAPPY_LIBRARIES)
+diff --git a/cmake/FindZSTD.cmake b/cmake/FindZSTD.cmake
+index ede59010742..d03e96fca15 100644
+--- a/cmake/FindZSTD.cmake
++++ b/cmake/FindZSTD.cmake
+@@ -1,11 +1,11 @@
+ # - Find zstd
+ # Find the zstd compression library and includes
+ #
+-# ZSTD_INCLUDE_DIR - where to find zstd.h, etc.
++# ZSTD_INCLUDE_DIRS - where to find zstd.h, etc.
+ # ZSTD_LIBRARIES - List of libraries when using zstd.
+ # ZSTD_FOUND - True if zstd found.
+ 
+-find_path(ZSTD_INCLUDE_DIR
++find_path(ZSTD_INCLUDE_DIRS
+   NAMES zstd.h
+   HINTS ${ZSTD_ROOT_DIR}/include)
+ 
+@@ -14,8 +14,8 @@ find_library(ZSTD_LIBRARIES
+   HINTS ${ZSTD_ROOT_DIR}/lib)
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIR)
++find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIRS)
+ 
+ mark_as_advanced(
+   ZSTD_LIBRARIES
+-  ZSTD_INCLUDE_DIR)
++  ZSTD_INCLUDE_DIRS)
+diff --git a/storage/oqgraph/cmake/FindJudy.cmake b/storage/oqgraph/cmake/FindJudy.cmake
+index d9ecfdc4a4f..37aed8b631c 100644
+--- a/storage/oqgraph/cmake/FindJudy.cmake
++++ b/storage/oqgraph/cmake/FindJudy.cmake
+@@ -16,7 +16,7 @@
+ # Once done this will define
+ #
+ #  Judy_FOUND - system has Judy
+-#  Judy_INCLUDE_DIR - the Judy include directory
++#  Judy_INCLUDE_DIRS - the Judy include directory
+ #  Judy_LIBRARIES - Link these to use Judy
+ #  Judy_DEFINITIONS - Compiler switches required for using Judy
+ 
+@@ -24,21 +24,21 @@ IF(MSVC)
+   # For now, assume Judy built according to the above instructions
+   if (NOT "$ENV{JUDY_ROOT}" STREQUAL "")
+     # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+-    string(REPLACE "\\" "/" Judy_INCLUDE_DIR_search $ENV{JUDY_ROOT}/src)
++    string(REPLACE "\\" "/" Judy_INCLUDE_DIRS_search $ENV{JUDY_ROOT}/src)
+     string(REPLACE "\\" "/" Judy_LIBRARIES_search $ENV{JUDY_ROOT}/src)
+   endif()
+ ELSE(MSVC)
+-  IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+       SET(Judy_FIND_QUIETLY TRUE)
+-  ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ ENDIF(MSVC)
+ 
+-FIND_PATH(Judy_INCLUDE_DIR Judy.h PATHS ${Judy_INCLUDE_DIR_search})
++FIND_PATH(Judy_INCLUDE_DIRS Judy.h PATHS ${Judy_INCLUDE_DIRS_search})
+ FIND_LIBRARY(Judy_LIBRARIES Judy PATHS ${Judy_LIBRARIES_search})
+ 
+-IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND TRUE)
+-ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ELSE (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND FALSE)
+   if (MSVC)
+     MESSAGE(STATUS "How to build Judy on Windows:")
+@@ -51,7 +51,7 @@ ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
+     MESSAGE(STATUS "3. Execute the command: 'build'")
+     MESSAGE(STATUS "4. Rerun this cmake with the environment variable: 'set JUDY_ROOT=x:\\path\\to\\judy'")
+   endif(MSVC)
+-ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ 
+ IF (Judy_FOUND)
+   IF (NOT Judy_FIND_QUIETLY)
+@@ -63,5 +63,5 @@ ELSE (Judy_FOUND)
+   ENDIF (Judy_FIND_REQUIRED)
+ ENDIF (Judy_FOUND)
+ 
+-MARK_AS_ADVANCED(Judy_INCLUDE_DIR Judy_LIBRARIES)
++MARK_AS_ADVANCED(Judy_INCLUDE_DIRS Judy_LIBRARIES)
+ 
+diff --git a/storage/rocksdb/build_rocksdb.cmake b/storage/rocksdb/build_rocksdb.cmake
+index 762368b4a80..f496b429e07 100644
+--- a/storage/rocksdb/build_rocksdb.cmake
++++ b/storage/rocksdb/build_rocksdb.cmake
+@@ -35,48 +35,48 @@ endif()
+ # Optional compression libraries.
+ 
+ include(CheckFunctionExists)
+-macro(check_lib package var)
+-  STRING(TOUPPER ${package} PACKAGE_NAME)
++macro(check_lib package)
+   SET(WITH_ROCKSDB_${package} AUTO CACHE STRING
+         "Build RocksDB  with ${package} compression. Possible values are 'ON', 'OFF', 'AUTO' and default is 'AUTO'")
+ 
++  STRING(TOUPPER ${package} var)
+   IF (NOT ${WITH_ROCKSDB_${package}} STREQUAL "OFF")
+     FIND_PACKAGE(${package} QUIET)
+-    SET(HAVE_ROCKSDB_${PACKAGE_NAME} TRUE)
+-    IF (${${PACKAGE_NAME}_FOUND})
+-      IF(${ARGC} GREATER 2)
++    SET(HAVE_ROCKSDB_${package} TRUE)
++    IF (${${package}_FOUND})
++      IF(${ARGC} GREATER 1)
+         SET(CMAKE_REQUIRED_LIBRARIES ${${var}_LIBRARIES})
+-        CHECK_FUNCTION_EXISTS(${ARGV2} ${var}_VALID)
++        CHECK_FUNCTION_EXISTS(${ARGV1} ${package}_VALID)
+         UNSET(CMAKE_REQUIRED_LIBRARIES)
+       ELSE()
+-        SET(${var}_VALID TRUE)
++        SET(${package}_VALID TRUE)
+       ENDIF()
+     ENDIF()
+   ENDIF()
+-  ADD_FEATURE_INFO(ROCKSDB_${PACKAGE_NAME} HAVE_ROCKSDB_${PACKAGE_NAME} "${package} Compression in the RocksDB storage engine")
++  ADD_FEATURE_INFO(ROCKSDB_${package} HAVE_ROCKSDB_${package} "${package} Compression in the RocksDB storage engine")
+ 
+-  IF(${${var}_VALID})
+-    MESSAGE_ONCE(rocksdb_${var} "Found ${package}: ${${var}_LIBRARIES}")
+-    add_definitions(-D${PACKAGE_NAME})
++  IF(${${package}_VALID})
++    MESSAGE_ONCE(rocksdb_${package} "Found ${package}: ${${var}_LIBRARIES}")
++    add_definitions(-D${var})
+     include_directories(${${var}_INCLUDE_DIR})
+     list(APPEND THIRDPARTY_LIBS ${${var}_LIBRARIES})
+-  ELSEIF(${${PACKAGE_NAME}_FOUND})
+-    MESSAGE_ONCE(rocksdb_${var} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV2}]")
++  ELSEIF(${${package}_FOUND})
++    MESSAGE_ONCE(rocksdb_${package} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV1}]")
+   ELSE()
+-    MESSAGE_ONCE(rocksdb_${var} "Could NOT find ${package}")
++    MESSAGE_ONCE(rocksdb_${package} "Could NOT find ${package}")
+   ENDIF()
+ 
+-  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${PACKAGE_NAME}_FOUND})
++  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${package}_FOUND})
+     MESSAGE(FATAL_ERROR
+       "${package} library was not found, but WITH_ROCKSDB_${package} option is ON.\
+       Either set WITH_ROCKSDB_${package} to OFF, or make sure ${package} is installed")
+   endif()
+ endmacro()
+ 
+-check_lib(LZ4    LZ4)
+-check_lib(BZip2  BZIP2)
+-check_lib(snappy snappy) # rocksdb/cmake/modules/Findsnappy.cmake violates the convention
+-check_lib(ZSTD   ZSTD ZDICT_trainFromBuffer)
++check_lib(LZ4)
++check_lib(BZip2)
++check_lib(Snappy)
++check_lib(ZSTD ZDICT_trainFromBuffer)
+ 
+ add_definitions(-DZLIB)
+ list(APPEND THIRDPARTY_LIBS ${ZLIB_LIBRARY})

--- a/patches/mariadb/10.5.25/find-libs.patch
+++ b/patches/mariadb/10.5.25/find-libs.patch
@@ -1,0 +1,205 @@
+diff --git a/cmake/FindLZ4.cmake b/cmake/FindLZ4.cmake
+index 46c1fdc1b9f..48a7790afcd 100644
+--- a/cmake/FindLZ4.cmake
++++ b/cmake/FindLZ4.cmake
+@@ -1,9 +1,9 @@
+-find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
++find_path(LZ4_INCLUDE_DIRS NAMES lz4.h)
+ find_library(LZ4_LIBRARIES NAMES lz4)
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     LZ4 DEFAULT_MSG
+-    LZ4_LIBRARIES LZ4_INCLUDE_DIR)
++    LZ4_LIBRARIES LZ4_INCLUDE_DIRS)
+ 
+-mark_as_advanced(LZ4_INCLUDE_DIR LZ4_LIBRARIES)
++mark_as_advanced(LZ4_INCLUDE_DIRS LZ4_LIBRARIES)
+diff --git a/cmake/FindLZO.cmake b/cmake/FindLZO.cmake
+new file mode 100644
+index 00000000000..04391bb4720
+--- /dev/null
++++ b/cmake/FindLZO.cmake
+@@ -0,0 +1,9 @@
++find_path(LZO_INCLUDE_DIRS NAMES lzo/lzo1x.h)
++find_library(LZO_LIBRARIES NAMES lzo2)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    LZO DEFAULT_MSG
++    LZO_LIBRARIES LZO_INCLUDE_DIRS)
++
++mark_as_advanced(LZO_INCLUDE_DIRS LZO_LIBRARIES)
+diff --git a/cmake/FindSnappy.cmake b/cmake/FindSnappy.cmake
+new file mode 100644
+index 00000000000..1e99eb65a50
+--- /dev/null
++++ b/cmake/FindSnappy.cmake
+@@ -0,0 +1,9 @@
++find_path(SNAPPY_INCLUDE_DIRS NAMES snappy.h)
++find_library(SNAPPY_LIBRARIES NAMES snappy)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    Snappy DEFAULT_MSG
++    SNAPPY_LIBRARIES SNAPPY_INCLUDE_DIRS)
++
++mark_as_advanced(SNAPPY_INCLUDE_DIRS SNAPPY_LIBRARIES)
+diff --git a/cmake/FindZSTD.cmake b/cmake/FindZSTD.cmake
+index ede59010742..d03e96fca15 100644
+--- a/cmake/FindZSTD.cmake
++++ b/cmake/FindZSTD.cmake
+@@ -1,11 +1,11 @@
+ # - Find zstd
+ # Find the zstd compression library and includes
+ #
+-# ZSTD_INCLUDE_DIR - where to find zstd.h, etc.
++# ZSTD_INCLUDE_DIRS - where to find zstd.h, etc.
+ # ZSTD_LIBRARIES - List of libraries when using zstd.
+ # ZSTD_FOUND - True if zstd found.
+ 
+-find_path(ZSTD_INCLUDE_DIR
++find_path(ZSTD_INCLUDE_DIRS
+   NAMES zstd.h
+   HINTS ${ZSTD_ROOT_DIR}/include)
+ 
+@@ -14,8 +14,8 @@ find_library(ZSTD_LIBRARIES
+   HINTS ${ZSTD_ROOT_DIR}/lib)
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIR)
++find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIRS)
+ 
+ mark_as_advanced(
+   ZSTD_LIBRARIES
+-  ZSTD_INCLUDE_DIR)
++  ZSTD_INCLUDE_DIRS)
+diff --git a/storage/oqgraph/cmake/FindJudy.cmake b/storage/oqgraph/cmake/FindJudy.cmake
+index d9ecfdc4a4f..37aed8b631c 100644
+--- a/storage/oqgraph/cmake/FindJudy.cmake
++++ b/storage/oqgraph/cmake/FindJudy.cmake
+@@ -16,7 +16,7 @@
+ # Once done this will define
+ #
+ #  Judy_FOUND - system has Judy
+-#  Judy_INCLUDE_DIR - the Judy include directory
++#  Judy_INCLUDE_DIRS - the Judy include directory
+ #  Judy_LIBRARIES - Link these to use Judy
+ #  Judy_DEFINITIONS - Compiler switches required for using Judy
+ 
+@@ -24,21 +24,21 @@ IF(MSVC)
+   # For now, assume Judy built according to the above instructions
+   if (NOT "$ENV{JUDY_ROOT}" STREQUAL "")
+     # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+-    string(REPLACE "\\" "/" Judy_INCLUDE_DIR_search $ENV{JUDY_ROOT}/src)
++    string(REPLACE "\\" "/" Judy_INCLUDE_DIRS_search $ENV{JUDY_ROOT}/src)
+     string(REPLACE "\\" "/" Judy_LIBRARIES_search $ENV{JUDY_ROOT}/src)
+   endif()
+ ELSE(MSVC)
+-  IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+       SET(Judy_FIND_QUIETLY TRUE)
+-  ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ ENDIF(MSVC)
+ 
+-FIND_PATH(Judy_INCLUDE_DIR Judy.h PATHS ${Judy_INCLUDE_DIR_search})
++FIND_PATH(Judy_INCLUDE_DIRS Judy.h PATHS ${Judy_INCLUDE_DIRS_search})
+ FIND_LIBRARY(Judy_LIBRARIES Judy PATHS ${Judy_LIBRARIES_search})
+ 
+-IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND TRUE)
+-ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ELSE (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND FALSE)
+   if (MSVC)
+     MESSAGE(STATUS "How to build Judy on Windows:")
+@@ -51,7 +51,7 @@ ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
+     MESSAGE(STATUS "3. Execute the command: 'build'")
+     MESSAGE(STATUS "4. Rerun this cmake with the environment variable: 'set JUDY_ROOT=x:\\path\\to\\judy'")
+   endif(MSVC)
+-ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ 
+ IF (Judy_FOUND)
+   IF (NOT Judy_FIND_QUIETLY)
+@@ -63,5 +63,5 @@ ELSE (Judy_FOUND)
+   ENDIF (Judy_FIND_REQUIRED)
+ ENDIF (Judy_FOUND)
+ 
+-MARK_AS_ADVANCED(Judy_INCLUDE_DIR Judy_LIBRARIES)
++MARK_AS_ADVANCED(Judy_INCLUDE_DIRS Judy_LIBRARIES)
+ 
+diff --git a/storage/rocksdb/build_rocksdb.cmake b/storage/rocksdb/build_rocksdb.cmake
+index 762368b4a80..f496b429e07 100644
+--- a/storage/rocksdb/build_rocksdb.cmake
++++ b/storage/rocksdb/build_rocksdb.cmake
+@@ -35,48 +35,48 @@ endif()
+ # Optional compression libraries.
+ 
+ include(CheckFunctionExists)
+-macro(check_lib package var)
+-  STRING(TOUPPER ${package} PACKAGE_NAME)
++macro(check_lib package)
+   SET(WITH_ROCKSDB_${package} AUTO CACHE STRING
+         "Build RocksDB  with ${package} compression. Possible values are 'ON', 'OFF', 'AUTO' and default is 'AUTO'")
+ 
++  STRING(TOUPPER ${package} var)
+   IF (NOT ${WITH_ROCKSDB_${package}} STREQUAL "OFF")
+     FIND_PACKAGE(${package} QUIET)
+-    SET(HAVE_ROCKSDB_${PACKAGE_NAME} TRUE)
+-    IF (${${PACKAGE_NAME}_FOUND})
+-      IF(${ARGC} GREATER 2)
++    SET(HAVE_ROCKSDB_${package} TRUE)
++    IF (${${package}_FOUND})
++      IF(${ARGC} GREATER 1)
+         SET(CMAKE_REQUIRED_LIBRARIES ${${var}_LIBRARIES})
+-        CHECK_FUNCTION_EXISTS(${ARGV2} ${var}_VALID)
++        CHECK_FUNCTION_EXISTS(${ARGV1} ${package}_VALID)
+         UNSET(CMAKE_REQUIRED_LIBRARIES)
+       ELSE()
+-        SET(${var}_VALID TRUE)
++        SET(${package}_VALID TRUE)
+       ENDIF()
+     ENDIF()
+   ENDIF()
+-  ADD_FEATURE_INFO(ROCKSDB_${PACKAGE_NAME} HAVE_ROCKSDB_${PACKAGE_NAME} "${package} Compression in the RocksDB storage engine")
++  ADD_FEATURE_INFO(ROCKSDB_${package} HAVE_ROCKSDB_${package} "${package} Compression in the RocksDB storage engine")
+ 
+-  IF(${${var}_VALID})
+-    MESSAGE_ONCE(rocksdb_${var} "Found ${package}: ${${var}_LIBRARIES}")
+-    add_definitions(-D${PACKAGE_NAME})
++  IF(${${package}_VALID})
++    MESSAGE_ONCE(rocksdb_${package} "Found ${package}: ${${var}_LIBRARIES}")
++    add_definitions(-D${var})
+     include_directories(${${var}_INCLUDE_DIR})
+     list(APPEND THIRDPARTY_LIBS ${${var}_LIBRARIES})
+-  ELSEIF(${${PACKAGE_NAME}_FOUND})
+-    MESSAGE_ONCE(rocksdb_${var} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV2}]")
++  ELSEIF(${${package}_FOUND})
++    MESSAGE_ONCE(rocksdb_${package} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV1}]")
+   ELSE()
+-    MESSAGE_ONCE(rocksdb_${var} "Could NOT find ${package}")
++    MESSAGE_ONCE(rocksdb_${package} "Could NOT find ${package}")
+   ENDIF()
+ 
+-  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${PACKAGE_NAME}_FOUND})
++  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${package}_FOUND})
+     MESSAGE(FATAL_ERROR
+       "${package} library was not found, but WITH_ROCKSDB_${package} option is ON.\
+       Either set WITH_ROCKSDB_${package} to OFF, or make sure ${package} is installed")
+   endif()
+ endmacro()
+ 
+-check_lib(LZ4    LZ4)
+-check_lib(BZip2  BZIP2)
+-check_lib(snappy snappy) # rocksdb/cmake/modules/Findsnappy.cmake violates the convention
+-check_lib(ZSTD   ZSTD ZDICT_trainFromBuffer)
++check_lib(LZ4)
++check_lib(BZip2)
++check_lib(Snappy)
++check_lib(ZSTD ZDICT_trainFromBuffer)
+ 
+ add_definitions(-DZLIB)
+ list(APPEND THIRDPARTY_LIBS ${ZLIB_LIBRARY})

--- a/patches/mariadb/10.6.18/find-libs.patch
+++ b/patches/mariadb/10.6.18/find-libs.patch
@@ -1,0 +1,283 @@
+diff --git a/cmake/FindLIBAIO.cmake b/cmake/FindLIBAIO.cmake
+index db49439f318..3a4205f7a45 100644
+--- a/cmake/FindLIBAIO.cmake
++++ b/cmake/FindLIBAIO.cmake
+@@ -1,7 +1,7 @@
+-find_path(LIBAIO_INCLUDE_DIR NAMES libaio.h)
++find_path(LIBAIO_INCLUDE_DIRS NAMES libaio.h)
+ find_library(LIBAIO_LIBRARIES NAMES aio)
+ 
+ include(FindPackageHandleStandardArgs)
+   FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     LIBAIO DEFAULT_MSG
+-    LIBAIO_LIBRARIES LIBAIO_INCLUDE_DIR)
++    LIBAIO_LIBRARIES LIBAIO_INCLUDE_DIRS)
+diff --git a/cmake/FindLZ4.cmake b/cmake/FindLZ4.cmake
+index 46c1fdc1b9f..48a7790afcd 100644
+--- a/cmake/FindLZ4.cmake
++++ b/cmake/FindLZ4.cmake
+@@ -1,9 +1,9 @@
+-find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
++find_path(LZ4_INCLUDE_DIRS NAMES lz4.h)
+ find_library(LZ4_LIBRARIES NAMES lz4)
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     LZ4 DEFAULT_MSG
+-    LZ4_LIBRARIES LZ4_INCLUDE_DIR)
++    LZ4_LIBRARIES LZ4_INCLUDE_DIRS)
+ 
+-mark_as_advanced(LZ4_INCLUDE_DIR LZ4_LIBRARIES)
++mark_as_advanced(LZ4_INCLUDE_DIRS LZ4_LIBRARIES)
+diff --git a/cmake/FindLZO.cmake b/cmake/FindLZO.cmake
+new file mode 100644
+index 00000000000..04391bb4720
+--- /dev/null
++++ b/cmake/FindLZO.cmake
+@@ -0,0 +1,9 @@
++find_path(LZO_INCLUDE_DIRS NAMES lzo/lzo1x.h)
++find_library(LZO_LIBRARIES NAMES lzo2)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    LZO DEFAULT_MSG
++    LZO_LIBRARIES LZO_INCLUDE_DIRS)
++
++mark_as_advanced(LZO_INCLUDE_DIRS LZO_LIBRARIES)
+diff --git a/cmake/FindPMEM.cmake b/cmake/FindPMEM.cmake
+index 73e71bc29f4..024436444d2 100644
+--- a/cmake/FindPMEM.cmake
++++ b/cmake/FindPMEM.cmake
+@@ -7,12 +7,12 @@ if(DEFINED PMEM_LIBRARIES)
+   return()
+ endif()
+ 
+-find_path(PMEM_INCLUDE_DIR NAMES libpmem.h)
++find_path(PMEM_INCLUDE_DIRS NAMES libpmem.h)
+ find_library(PMEM_LIBRARIES NAMES pmem)
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     PMEM DEFAULT_MSG
+-    PMEM_LIBRARIES PMEM_INCLUDE_DIR)
++    PMEM_LIBRARIES PMEM_INCLUDE_DIRS)
+ 
+-mark_as_advanced(PMEM_INCLUDE_DIR PMEM_LIBRARIES)
++mark_as_advanced(PMEM_INCLUDE_DIRS PMEM_LIBRARIES)
+diff --git a/cmake/FindSnappy.cmake b/cmake/FindSnappy.cmake
+new file mode 100644
+index 00000000000..1e99eb65a50
+--- /dev/null
++++ b/cmake/FindSnappy.cmake
+@@ -0,0 +1,9 @@
++find_path(SNAPPY_INCLUDE_DIRS NAMES snappy.h)
++find_library(SNAPPY_LIBRARIES NAMES snappy)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    Snappy DEFAULT_MSG
++    SNAPPY_LIBRARIES SNAPPY_INCLUDE_DIRS)
++
++mark_as_advanced(SNAPPY_INCLUDE_DIRS SNAPPY_LIBRARIES)
+diff --git a/cmake/FindURING.cmake b/cmake/FindURING.cmake
+index 6e5e0783b46..b8141c9d480 100644
+--- a/cmake/FindURING.cmake
++++ b/cmake/FindURING.cmake
+@@ -1,9 +1,9 @@
+-find_path(URING_INCLUDE_DIR NAMES liburing.h)
++find_path(URING_INCLUDE_DIRS NAMES liburing.h)
+ find_library(URING_LIBRARIES NAMES uring)
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+     URING DEFAULT_MSG
+-    URING_LIBRARIES URING_INCLUDE_DIR)
++    URING_LIBRARIES URING_INCLUDE_DIRS)
+ 
+-mark_as_advanced(URING_INCLUDE_DIR URING_LIBRARIES)
++mark_as_advanced(URING_INCLUDE_DIRS URING_LIBRARIES)
+diff --git a/cmake/FindZSTD.cmake b/cmake/FindZSTD.cmake
+index ede59010742..d03e96fca15 100644
+--- a/cmake/FindZSTD.cmake
++++ b/cmake/FindZSTD.cmake
+@@ -1,11 +1,11 @@
+ # - Find zstd
+ # Find the zstd compression library and includes
+ #
+-# ZSTD_INCLUDE_DIR - where to find zstd.h, etc.
++# ZSTD_INCLUDE_DIRS - where to find zstd.h, etc.
+ # ZSTD_LIBRARIES - List of libraries when using zstd.
+ # ZSTD_FOUND - True if zstd found.
+ 
+-find_path(ZSTD_INCLUDE_DIR
++find_path(ZSTD_INCLUDE_DIRS
+   NAMES zstd.h
+   HINTS ${ZSTD_ROOT_DIR}/include)
+ 
+@@ -14,8 +14,8 @@ find_library(ZSTD_LIBRARIES
+   HINTS ${ZSTD_ROOT_DIR}/lib)
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIR)
++find_package_handle_standard_args(ZSTD DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIRS)
+ 
+ mark_as_advanced(
+   ZSTD_LIBRARIES
+-  ZSTD_INCLUDE_DIR)
++  ZSTD_INCLUDE_DIRS)
+diff --git a/storage/oqgraph/cmake/FindJudy.cmake b/storage/oqgraph/cmake/FindJudy.cmake
+index d9ecfdc4a4f..37aed8b631c 100644
+--- a/storage/oqgraph/cmake/FindJudy.cmake
++++ b/storage/oqgraph/cmake/FindJudy.cmake
+@@ -16,7 +16,7 @@
+ # Once done this will define
+ #
+ #  Judy_FOUND - system has Judy
+-#  Judy_INCLUDE_DIR - the Judy include directory
++#  Judy_INCLUDE_DIRS - the Judy include directory
+ #  Judy_LIBRARIES - Link these to use Judy
+ #  Judy_DEFINITIONS - Compiler switches required for using Judy
+ 
+@@ -24,21 +24,21 @@ IF(MSVC)
+   # For now, assume Judy built according to the above instructions
+   if (NOT "$ENV{JUDY_ROOT}" STREQUAL "")
+     # Avoid passing backslashes to _Boost_FIND_LIBRARY due to macro re-parsing.
+-    string(REPLACE "\\" "/" Judy_INCLUDE_DIR_search $ENV{JUDY_ROOT}/src)
++    string(REPLACE "\\" "/" Judy_INCLUDE_DIRS_search $ENV{JUDY_ROOT}/src)
+     string(REPLACE "\\" "/" Judy_LIBRARIES_search $ENV{JUDY_ROOT}/src)
+   endif()
+ ELSE(MSVC)
+-  IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+       SET(Judy_FIND_QUIETLY TRUE)
+-  ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++  ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ ENDIF(MSVC)
+ 
+-FIND_PATH(Judy_INCLUDE_DIR Judy.h PATHS ${Judy_INCLUDE_DIR_search})
++FIND_PATH(Judy_INCLUDE_DIRS Judy.h PATHS ${Judy_INCLUDE_DIRS_search})
+ FIND_LIBRARY(Judy_LIBRARIES Judy PATHS ${Judy_LIBRARIES_search})
+ 
+-IF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++IF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND TRUE)
+-ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ELSE (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+   SET(Judy_FOUND FALSE)
+   if (MSVC)
+     MESSAGE(STATUS "How to build Judy on Windows:")
+@@ -51,7 +51,7 @@ ELSE (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
+     MESSAGE(STATUS "3. Execute the command: 'build'")
+     MESSAGE(STATUS "4. Rerun this cmake with the environment variable: 'set JUDY_ROOT=x:\\path\\to\\judy'")
+   endif(MSVC)
+-ENDIF (Judy_INCLUDE_DIR AND Judy_LIBRARIES)
++ENDIF (Judy_INCLUDE_DIRS AND Judy_LIBRARIES)
+ 
+ IF (Judy_FOUND)
+   IF (NOT Judy_FIND_QUIETLY)
+@@ -63,5 +63,5 @@ ELSE (Judy_FOUND)
+   ENDIF (Judy_FIND_REQUIRED)
+ ENDIF (Judy_FOUND)
+ 
+-MARK_AS_ADVANCED(Judy_INCLUDE_DIR Judy_LIBRARIES)
++MARK_AS_ADVANCED(Judy_INCLUDE_DIRS Judy_LIBRARIES)
+ 
+diff --git a/storage/rocksdb/build_rocksdb.cmake b/storage/rocksdb/build_rocksdb.cmake
+index fd23b7ba470..29b2d83a759 100644
+--- a/storage/rocksdb/build_rocksdb.cmake
++++ b/storage/rocksdb/build_rocksdb.cmake
+@@ -35,48 +35,48 @@ endif()
+ # Optional compression libraries.
+ 
+ include(CheckFunctionExists)
+-macro(check_lib package var)
+-  STRING(TOUPPER ${package} PACKAGE_NAME)
++macro(check_lib package)
+   SET(WITH_ROCKSDB_${package} AUTO CACHE STRING
+         "Build RocksDB  with ${package} compression. Possible values are 'ON', 'OFF', 'AUTO' and default is 'AUTO'")
+ 
++  STRING(TOUPPER ${package} var)
+   IF (NOT ${WITH_ROCKSDB_${package}} STREQUAL "OFF")
+     FIND_PACKAGE(${package} QUIET)
+-    SET(HAVE_ROCKSDB_${PACKAGE_NAME} TRUE)
+-    IF (${${PACKAGE_NAME}_FOUND})
+-      IF(${ARGC} GREATER 2)
++    SET(HAVE_ROCKSDB_${package} TRUE)
++    IF (${${package}_FOUND})
++      IF(${ARGC} GREATER 1)
+         SET(CMAKE_REQUIRED_LIBRARIES ${${var}_LIBRARIES})
+-        CHECK_FUNCTION_EXISTS(${ARGV2} ${var}_VALID)
++        CHECK_FUNCTION_EXISTS(${ARGV1} ${package}_VALID)
+         UNSET(CMAKE_REQUIRED_LIBRARIES)
+       ELSE()
+-        SET(${var}_VALID TRUE)
++        SET(${package}_VALID TRUE)
+       ENDIF()
+     ENDIF()
+   ENDIF()
+-  ADD_FEATURE_INFO(ROCKSDB_${PACKAGE_NAME} HAVE_ROCKSDB_${PACKAGE_NAME} "${package} Compression in the RocksDB storage engine")
++  ADD_FEATURE_INFO(ROCKSDB_${package} HAVE_ROCKSDB_${package} "${package} Compression in the RocksDB storage engine")
+ 
+-  IF(${${var}_VALID})
+-    MESSAGE_ONCE(rocksdb_${var} "Found ${package}: ${${var}_LIBRARIES}")
+-    add_definitions(-D${PACKAGE_NAME})
++  IF(${${package}_VALID})
++    MESSAGE_ONCE(rocksdb_${package} "Found ${package}: ${${var}_LIBRARIES}")
++    add_definitions(-D${var})
+     include_directories(${${var}_INCLUDE_DIR})
+     list(APPEND THIRDPARTY_LIBS ${${var}_LIBRARIES})
+-  ELSEIF(${${PACKAGE_NAME}_FOUND})
+-    MESSAGE_ONCE(rocksdb_${var} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV2}]")
++  ELSEIF(${${package}_FOUND})
++    MESSAGE_ONCE(rocksdb_${package} "Found unusable ${package}: ${${var}_LIBRARIES} [${ARGV1}]")
+   ELSE()
+-    MESSAGE_ONCE(rocksdb_${var} "Could NOT find ${package}")
++    MESSAGE_ONCE(rocksdb_${package} "Could NOT find ${package}")
+   ENDIF()
+ 
+-  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${PACKAGE_NAME}_FOUND})
++  IF (${WITH_ROCKSDB_${package}} STREQUAL "ON"  AND NOT ${${package}_FOUND})
+     MESSAGE(FATAL_ERROR
+       "${package} library was not found, but WITH_ROCKSDB_${package} option is ON.\
+       Either set WITH_ROCKSDB_${package} to OFF, or make sure ${package} is installed")
+   endif()
+ endmacro()
+ 
+-check_lib(LZ4    LZ4)
+-check_lib(BZip2  BZIP2)
+-check_lib(snappy snappy) # rocksdb/cmake/modules/Findsnappy.cmake violates the convention
+-check_lib(ZSTD   ZSTD ZDICT_trainFromBuffer)
++check_lib(LZ4)
++check_lib(BZip2)
++check_lib(Snappy)
++check_lib(ZSTD ZDICT_trainFromBuffer)
+ 
+ add_definitions(-DZLIB)
+ list(APPEND THIRDPARTY_LIBS ${ZLIB_LIBRARY})
+diff --git a/tpool/CMakeLists.txt b/tpool/CMakeLists.txt
+index 3a49ea22837..115e3d58634 100644
+--- a/tpool/CMakeLists.txt
++++ b/tpool/CMakeLists.txt
+@@ -15,11 +15,11 @@ ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     SET(TPOOL_DEFINES "-DHAVE_URING" PARENT_SCOPE)
+     ADD_DEFINITIONS(-DHAVE_URING)
+     LINK_LIBRARIES(${URING_LIBRARIES})
+-    INCLUDE_DIRECTORIES(${URING_INCLUDE_DIR})
++    INCLUDE_DIRECTORIES(${URING_INCLUDE_DIRS})
+     SET(EXTRA_SOURCES aio_liburing.cc)
+     SET(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
+     SET(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
+-    SET(CMAKE_REQUIRED_INCLUDES ${URING_INCLUDE_DIR})
++    SET(CMAKE_REQUIRED_INCLUDES ${URING_INCLUDE_DIRS})
+     SET(CMAKE_REQUIRED_LIBRARIES ${URING_LIBRARIES})
+     CHECK_SYMBOL_EXISTS(io_uring_mlock_size "liburing.h" HAVE_IO_URING_MLOCK_SIZE)
+     SET(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
+@@ -32,7 +32,7 @@ ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     IF(LIBAIO_FOUND)
+       SET(TPOOL_DEFINES "-DLINUX_NATIVE_AIO" PARENT_SCOPE)
+       ADD_DEFINITIONS(-DLINUX_NATIVE_AIO)
+-      INCLUDE_DIRECTORIES(${LIBAIO_INCLUDE_DIR})
++      INCLUDE_DIRECTORIES(${LIBAIO_INCLUDE_DIRS})
+       LINK_LIBRARIES(${LIBAIO_LIBRARIES})
+       SET(EXTRA_SOURCES aio_linux.cc)
+     ENDIF()

--- a/patches/mariadb/10.6.18/find-libs.patch
+++ b/patches/mariadb/10.6.18/find-libs.patch
@@ -44,26 +44,6 @@ index 00000000000..04391bb4720
 +    LZO_LIBRARIES LZO_INCLUDE_DIRS)
 +
 +mark_as_advanced(LZO_INCLUDE_DIRS LZO_LIBRARIES)
-diff --git a/cmake/FindPMEM.cmake b/cmake/FindPMEM.cmake
-index 73e71bc29f4..024436444d2 100644
---- a/cmake/FindPMEM.cmake
-+++ b/cmake/FindPMEM.cmake
-@@ -7,12 +7,12 @@ if(DEFINED PMEM_LIBRARIES)
-   return()
- endif()
- 
--find_path(PMEM_INCLUDE_DIR NAMES libpmem.h)
-+find_path(PMEM_INCLUDE_DIRS NAMES libpmem.h)
- find_library(PMEM_LIBRARIES NAMES pmem)
- 
- include(FindPackageHandleStandardArgs)
- FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-     PMEM DEFAULT_MSG
--    PMEM_LIBRARIES PMEM_INCLUDE_DIR)
-+    PMEM_LIBRARIES PMEM_INCLUDE_DIRS)
- 
--mark_as_advanced(PMEM_INCLUDE_DIR PMEM_LIBRARIES)
-+mark_as_advanced(PMEM_INCLUDE_DIRS PMEM_LIBRARIES)
 diff --git a/cmake/FindSnappy.cmake b/cmake/FindSnappy.cmake
 new file mode 100644
 index 00000000000..1e99eb65a50


### PR DESCRIPTION
After running git-bisect, it was found that the build fails due to https://github.com/MariaDB/server/commit/55cb2c2916a26b699ed8260427002243682c7110.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved consistency in naming conventions for include directories and library paths in the build scripts.
  - Updated build scripts to include bundled ZLIB and PCRE for MariaDB.
  - Added new configuration files for LZO, Snappy, and URING libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->