### PR TITLE
remove tests from MariaDB builds

### DIFF
--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -156,6 +156,7 @@ echo "::group::archive"
 
     # remove extra files
     rm -rf ./man
+    rm -rf ./mariadb-test
     rm -rf ./mysql-test
     rm -rf ./sql-bench
 

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -190,6 +190,7 @@ echo "::group::archive"
 
     # remove extra files
     rm -rf ./man
+    rm -rf ./mariadb-test
     rm -rf ./mysql-test
     rm -rf ./sql-bench
 

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -160,6 +160,9 @@ Expand-Archive -Path ".\build\mariadb-$MARIADB_VERSION-winx64.zip" -DestinationP
 Set-Location "mariadb-$MARIADB_VERSION-winx64"
 
 # remove extra files
+if (Test-Path mariadb-test) {
+    Remove-Item -Path mariadb-test -Recurse -Force
+}
 if (Test-Path mysql-test) {
     Remove-Item -Path mysql-test -Recurse -Force
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved cleanup process by removing the `mariadb-test` directory during MariaDB build on all platforms (Darwin, Linux, Windows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->