### PR TITLE
drop support of macos-11

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -59,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   build-darwin-x64:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -59,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   build-darwin-x64:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
           - macos-14
           - macos-13
           - macos-12
-          - macos-11
           - windows-2022
           - windows-2019
         mysql:
@@ -51,6 +50,7 @@ jobs:
           - "8.0"
           - "5.7"
           - "5.6"
+          - "mariadb-11.5"
           - "mariadb-11.4"
           - "mariadb-11.3"
           - "mariadb-11.2"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Available Versions are:
   - `5.7`
   - `5.6`
 - MariaDB
+  - `11.5`
   - `11.4`
   - `11.3`
   - `11.2`


### PR DESCRIPTION
macos-11 is now deprecated and will be removed in June 2024.

- ref. https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated README to include MariaDB version 11.5 in the list of available versions.

- **Chores**
  - Updated GitHub Actions workflows to build on `macos-12` instead of `macos-11`.
  - Added MariaDB version 11.5 to the test configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->