### PR TITLE
attest build provenance

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -57,6 +57,9 @@ jobs:
           gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/mariadb-$MARIADB_VERSION-$BUILD_OS-x64.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-x64:
     runs-on: macos-12
@@ -79,6 +82,9 @@ jobs:
         env:
           MARIADB_VERSION: ${{ matrix.mariadb }}
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-arm64:
     runs-on: macos-14
@@ -101,6 +107,9 @@ jobs:
         env:
           MARIADB_VERSION: ${{ matrix.mariadb }}
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-windows:
     runs-on: windows-2022
@@ -124,3 +133,6 @@ jobs:
         env:
           MARIADB_VERSION: ${{ matrix.mariadb }}
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.zip

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -153,4 +153,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ${{ runner.temp }}/*.zip
+          subject-path: C:\Temp\*.zip

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -10,6 +10,10 @@ on:
         description: MariaDB versions to build (JSON Array)
         required: false
         default: ""
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   list:
@@ -48,10 +52,6 @@ jobs:
       MARIADB_VERSION: ${{ matrix.mariadb }}
       BUILD_OS: ${{ matrix.os }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-linux.sh "$MARIADB_VERSION"
@@ -76,10 +76,6 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-darwin.sh ${{ matrix.mariadb }}
@@ -105,10 +101,6 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-darwin.sh ${{ matrix.mariadb }}
@@ -134,10 +126,6 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github\build-mariadb-windows.ps1 $env:MARIADB_VERSION

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -15,6 +15,8 @@ jobs:
   list:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
@@ -46,6 +48,10 @@ jobs:
       MARIADB_VERSION: ${{ matrix.mariadb }}
       BUILD_OS: ${{ matrix.os }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-linux.sh "$MARIADB_VERSION"
@@ -70,6 +76,10 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-darwin.sh ${{ matrix.mariadb }}
@@ -95,6 +105,10 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mariadb-darwin.sh ${{ matrix.mariadb }}
@@ -120,6 +134,10 @@ jobs:
     env:
       MARIADB_VERSION: ${{ matrix.mariadb }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github\build-mariadb-windows.ps1 $env:MARIADB_VERSION

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -15,6 +15,8 @@ jobs:
   list:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
@@ -46,6 +48,10 @@ jobs:
       MYSQL_VERSION: ${{ matrix.mysql }}
       BUILD_OS: ${{ matrix.os }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mysql-linux.sh "$MYSQL_VERSION"
@@ -70,6 +76,10 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -98,6 +108,10 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -57,6 +57,9 @@ jobs:
           gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/mysql-$MYSQL_VERSION-$BUILD_OS-x64.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-x64:
     runs-on: macos-12
@@ -82,6 +85,9 @@ jobs:
           gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/mysql-$MYSQL_VERSION-darwin-x64.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-arm64:
     runs-on: macos-14
@@ -107,6 +113,9 @@ jobs:
           gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/mysql-$MYSQL_VERSION-darwin-arm64.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-windows:
     runs-on: ${{ startsWith(matrix.mysql, '5.') && 'windows-2019' || 'windows-2022' }}
@@ -129,3 +138,6 @@ jobs:
           gh release upload --clobber "$ACTIONS_VERSION" "$TEMP_DIR/mysql-$MYSQL_VERSION-win32-x64.zip"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ runner.temp }}/*.zip

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -140,6 +140,10 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github\build-mysql-windows.ps1 $env:MYSQL_VERSION

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -158,4 +158,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ${{ runner.temp }}/*.zip
+          subject-path: C:\Temp\*.zip

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   list:
     runs-on: ubuntu-latest
@@ -48,10 +53,6 @@ jobs:
       MYSQL_VERSION: ${{ matrix.mysql }}
       BUILD_OS: ${{ matrix.os }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github/build-mysql-linux.sh "$MYSQL_VERSION"
@@ -76,10 +77,6 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -108,10 +105,6 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -140,10 +133,6 @@ jobs:
     env:
       MYSQL_VERSION: ${{ matrix.mysql }}
     timeout-minutes: 180
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - run: .github\build-mysql-windows.ps1 $env:MYSQL_VERSION


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added build provenance attestation for MariaDB and MySQL workflows.
  - Updated permissions settings in the MySQL workflow to enhance security and build integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->