### PR TITLE
export LIBMYSQL_PLUGIN_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,7 @@ Here are some examples:
 ### `MYSQL_HOME`
 
 The path to the directory in which the server-specific my.cnf file resides.
+
+### `LIBMYSQL_PLUGIN_DIR`
+
+Directory in which to look for client plugins.

--- a/src/starter.ts
+++ b/src/starter.ts
@@ -219,6 +219,9 @@ export async function startMySQL(
   // MYSQL_HOME: The path to the directory in which the server-specific my.cnf file resides.
   core.exportVariable("MYSQL_HOME", `${baseDir}${sep}etc`);
 
+  // LIBMYSQL_PLUGIN_DIR: Directory in which to look for client plugins.
+  core.exportVariable("LIBMYSQL_PLUGIN_DIR", `${mysql.toolPath}${sep}lib${sep}plugin`);
+
   return {
     pid,
     pidFile,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new configuration options: `LIBMYSQL_PLUGIN_DIR` to specify the directory for client plugins and `MYSQL_HOME` for the server-specific my.cnf file.

- **Documentation**
  - Updated README to include descriptions for new configuration variables `LIBMYSQL_PLUGIN_DIR` and `MYSQL_HOME`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->