### PR TITLE
fix openssl version

### DIFF
--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -32,7 +32,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^10\.([89]|[1-9][0-9]+)\.|^1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL 3 source"

--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -35,7 +35,7 @@ ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -43,7 +43,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -51,7 +51,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 3"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-openssl-$OPENSSL_VERSION"
@@ -64,7 +64,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
 else
     # build OpenSSL v1.1.1
     export OPENSSL_VERSION=$OPENSSL_VERSION1_1_1
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -72,7 +72,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -80,7 +80,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 1.1"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"

--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -32,7 +32,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9]\.([89]|[1-9][0-9]+)\. ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL source"

--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -32,7 +32,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ (^10[.](8|9|[1-9][0-9])[.])|(^1[1-9][.]) ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9]\.([89]|[1-9][0-9]+)\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL source"

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -76,7 +76,7 @@ ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -84,7 +84,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -92,7 +92,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 3"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-openssl-$OPENSSL_VERSION"
@@ -105,7 +105,7 @@ if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # Mari
 else
     # build OpenSSL v1.1.1
     export OPENSSL_VERSION=$OPENSSL_VERSION1_1_1
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -113,7 +113,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -121,7 +121,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 1.1"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -73,7 +73,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9][.]([89]|1[0-9]+)[.] ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9]\.([89]|[1-9][0-9]+)\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL source"

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -73,7 +73,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9]\.([89]|[1-9][0-9]+)\. ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL source"

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -73,7 +73,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MARIADB_VERSION" =~ ^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\. ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^10\.([89]|[1-9][0-9]+)\.|^1[1-9]\. ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL 3 source"

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -73,7 +73,7 @@ cd "$RUNNER_TEMP"
 
 ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 
-if [[ "$MYSQL_VERSION" =~ ^[1-9][0-9][.]([89]|1[0-9]+)[.] ]]; then # MariaDB 10.8 or later
+if [[ "$MARIADB_VERSION" =~ ^[1-9][0-9][.]([89]|1[0-9]+)[.] ]]; then # MariaDB 10.8 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
     echo "::group::download OpenSSL source"

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -39,7 +39,7 @@ Write-Host "::endgroup::"
 
 
 # system SSL/TLS library is too old. so we use custom build.
-if ( $MARIADB_VERSION -match '^[1-9][0-9][.]([89]|1[0-9]+)[.]') # # MariaDB 10.8 or later
+if ( $MARIADB_VERSION -match '^[1-9][0-9]\.([89]|[1-9][0-9]+)\.' ) # # MariaDB 10.8 or later
 {
     $OPENSSL_VERSION = $OPENSSL_VERSION3
     Write-Host "::group::fetch OpenSSL source"

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -42,7 +42,7 @@ Write-Host "::endgroup::"
 if ( $MARIADB_VERSION -match '^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\.' ) # # MariaDB 10.8 or later
 {
     $OPENSSL_VERSION = $OPENSSL_VERSION3
-    Write-Host "::group::fetch OpenSSL source"
+    Write-Host "::group::fetch OpenSSL 3 source"
     Set-Location "$RUNNER_TEMP"
     Write-Host "Downloading zip archive..."
     Invoke-WebRequest "https://github.com/openssl/openssl/archive/openssl-$OPENSSL_VERSION.zip" -OutFile "openssl.zip"
@@ -67,7 +67,7 @@ if ( $MARIADB_VERSION -match '^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\.' ) # # MariaD
     Write-Host "::endgroup::"
 } else {
     $OPENSSL_VERSION = $OPENSSL_VERSION1_1_1
-    Write-Host "::group::fetch OpenSSL source"
+    Write-Host "::group::fetch OpenSSL 1.1 source"
     Set-Location "$RUNNER_TEMP"
     Write-Host "Downloading zip archive..."
     Invoke-WebRequest "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.zip" -OutFile "openssl.zip"

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -39,7 +39,7 @@ Write-Host "::endgroup::"
 
 
 # system SSL/TLS library is too old. so we use custom build.
-if ( $MARIADB_VERSION -match '^[1-9][0-9]\.([89]|[1-9][0-9]+)\.' ) # # MariaDB 10.8 or later
+if ( $MARIADB_VERSION -match '^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\.' ) # # MariaDB 10.8 or later
 {
     $OPENSSL_VERSION = $OPENSSL_VERSION3
     Write-Host "::group::fetch OpenSSL source"

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -39,7 +39,7 @@ Write-Host "::endgroup::"
 
 
 # system SSL/TLS library is too old. so we use custom build.
-if ( $MARIADB_VERSION -match '^(10\.([89]|[1-9][0-9]+)\.)|1[1-9]\.' ) # # MariaDB 10.8 or later
+if ( $MARIADB_VERSION -match '^10\.([89]|[1-9][0-9]+)\.|^1[1-9]\.' ) # # MariaDB 10.8 or later
 {
     $OPENSSL_VERSION = $OPENSSL_VERSION3
     Write-Host "::group::fetch OpenSSL 3 source"

--- a/.github/build-mysql-darwin-macos14.sh
+++ b/.github/build-mysql-darwin-macos14.sh
@@ -4,7 +4,7 @@ set -e
 
 MYSQL_VERSION=$1
 OPENSSL_VERSION1_1_1=1_1_1w
-OPENSSL_VERSION3=3.2.1
+OPENSSL_VERSION3=3.3.1
 ROOT=$(cd "$(dirname "$0")" && pwd)
 : "${RUNNER_TEMP:=$ROOT/working}"
 : "${RUNNER_TOOL_CACHE:=$RUNNER_TEMP/dist}"
@@ -37,7 +37,7 @@ ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -45,7 +45,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -53,7 +53,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 3"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-openssl-$OPENSSL_VERSION"
@@ -66,7 +66,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
 else
     # build OpenSSL v1.1.1
     export OPENSSL_VERSION=$OPENSSL_VERSION1_1_1
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -74,7 +74,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -82,7 +82,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 1.1"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"

--- a/.github/build-mysql-darwin.sh
+++ b/.github/build-mysql-darwin.sh
@@ -48,7 +48,7 @@ ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -56,7 +56,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -64,7 +64,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 3"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-openssl-$OPENSSL_VERSION"
@@ -77,7 +77,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
 else
     # build OpenSSL v1.1.1
     export OPENSSL_VERSION=$OPENSSL_VERSION1_1_1
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -85,7 +85,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -93,7 +93,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 1.1"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"

--- a/.github/build-mysql-linux.sh
+++ b/.github/build-mysql-linux.sh
@@ -92,7 +92,7 @@ ACTION_VERSION=$(jq -r '.version' < "$ROOT/../package.json")
 if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     # build OpenSSL v3
     export OPENSSL_VERSION=$OPENSSL_VERSION3
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -100,7 +100,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 3 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -108,7 +108,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 3"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-openssl-$OPENSSL_VERSION"
@@ -121,7 +121,7 @@ if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|[89][.]) ]]; then # MySQL 8.0 or later
 else
     # build OpenSSL v1.1.1
     export OPENSSL_VERSION=$OPENSSL_VERSION1_1_1
-    echo "::group::download OpenSSL source"
+    echo "::group::download OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -129,7 +129,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::extract OpenSSL source"
+    echo "::group::extract OpenSSL 1.1 source"
     (
         set -eux
         cd "$RUNNER_TEMP"
@@ -137,7 +137,7 @@ else
     )
     echo "::endgroup::"
 
-    echo "::group::build OpenSSL"
+    echo "::group::build OpenSSL 1.1"
     (
         set -eux
         cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"

--- a/.github/build-mysql-windows.ps1
+++ b/.github/build-mysql-windows.ps1
@@ -61,7 +61,7 @@ Write-Host "::endgroup::"
 if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|[89][.])') # MySQL 8.0 or later
 {
     $OPENSSL_VERSION = $OPENSSL_VERSION3
-    Write-Host "::group::fetch OpenSSL source"
+    Write-Host "::group::fetch OpenSSL 3 source"
     Set-Location "$RUNNER_TEMP"
     Write-Host "Downloading zip archive..."
     Invoke-WebRequest "https://github.com/openssl/openssl/archive/openssl-$OPENSSL_VERSION.zip" -OutFile "openssl.zip"
@@ -70,7 +70,7 @@ if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|[89][.])') # MySQL 8.0 or later
     Remove-Item -Path "openssl.zip"
     Write-Host "::endgroup::"
 
-    Write-Host "::group::build OpenSSL"
+    Write-Host "::group::build OpenSSL 3"
     Set-Location "$RUNNER_TEMP"
     Set-Location "openssl-openssl-$OPENSSL_VERSION"
 
@@ -86,7 +86,7 @@ if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|[89][.])') # MySQL 8.0 or later
     Write-Host "::endgroup::"
 } else {
     $OPENSSL_VERSION = $OPENSSL_VERSION1_1_1
-    Write-Host "::group::fetch OpenSSL source"
+    Write-Host "::group::fetch OpenSSL 1.1 source"
     Set-Location "$RUNNER_TEMP"
     Write-Host "Downloading zip archive..."
     Invoke-WebRequest "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.zip" -OutFile "openssl.zip"
@@ -95,7 +95,7 @@ if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|[89][.])') # MySQL 8.0 or later
     Remove-Item -Path "openssl.zip"
     Write-Host "::endgroup::"
 
-    Write-Host "::group::build OpenSSL"
+    Write-Host "::group::build OpenSSL 1.1"
     Set-Location "$RUNNER_TEMP"
     Set-Location "openssl-OpenSSL_$OPENSSL_VERSION"
 
@@ -166,7 +166,7 @@ New-Item "boost" -ItemType Directory -Force
 $BOOST = Join-Path $RUNNER_TEMP "boost"
 New-Item "build" -ItemType Directory -Force
 Set-Location build
-if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|9[.])' ) # MySQL 8.0 or later
+if ( $MYSQL_VERSION -match '^([1-9][0-9][.]|9[.])' ) # MySQL 9.0 or later
 {
     cmake ( Join-Path $RUNNER_TEMP "mysql-server-mysql-$MYSQL_VERSION" ) `
         -DCOMPILATION_COMMENT="shogo82148/actions-setup-mysql@v$ACTION_VERSION" `


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the build scripts to focus on MariaDB versioning, enhancing compatibility with MariaDB 10.8 and later.
	- Clarified output messages in build scripts to specify the versions of OpenSSL being processed.

- **Bug Fixes**
	- Improved the accuracy of version checks in the build scripts for MariaDB and MySQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->