### PR TITLE
chore: Update OpenSSL version in build scripts

### DIFF
--- a/.github/build-mysql-darwin-macos14.sh
+++ b/.github/build-mysql-darwin-macos14.sh
@@ -4,7 +4,7 @@ set -e
 
 MYSQL_VERSION=$1
 OPENSSL_VERSION1_1_1=1_1_1w
-OPENSSL_VERSION3=3.2.1
+OPENSSL_VERSION3=3.3.1
 ROOT=$(cd "$(dirname "$0")" && pwd)
 : "${RUNNER_TEMP:=$ROOT/working}"
 : "${RUNNER_TOOL_CACHE:=$RUNNER_TEMP/dist}"

--- a/.github/update-dependencies.sh
+++ b/.github/update-dependencies.sh
@@ -12,6 +12,7 @@ perl -i -pe 's/^OPENSSL_VERSION1_1_1=.*$/OPENSSL_VERSION1_1_1=$ENV{OPENSSL_VERSI
 perl -i -pe 's/^\$OPENSSL_VERSION1_1_1\s*=.*$/\$OPENSSL_VERSION1_1_1 = "$ENV{OPENSSL_VERSION1_1_1}"/' build-mariadb-windows.ps1
 
 perl -i -pe 's/^OPENSSL_VERSION1_1_1=.*$/OPENSSL_VERSION1_1_1=$ENV{OPENSSL_VERSION1_1_1}/' build-mysql-darwin.sh
+perl -i -pe 's/^OPENSSL_VERSION1_1_1=.*$/OPENSSL_VERSION1_1_1=$ENV{OPENSSL_VERSION1_1_1}/' build-mysql-darwin-macos14.sh
 perl -i -pe 's/^OPENSSL_VERSION1_1_1=.*$/OPENSSL_VERSION1_1_1=$ENV{OPENSSL_VERSION1_1_1}/' build-mysql-linux.sh
 perl -i -pe 's/^\$OPENSSL_VERSION1_1_1\s*=.*$/\$OPENSSL_VERSION1_1_1 = "$ENV{OPENSSL_VERSION1_1_1}"/' build-mysql-windows.ps1
 
@@ -23,5 +24,6 @@ perl -i -pe 's/^OPENSSL_VERSION3=.*$/OPENSSL_VERSION3=$ENV{OPENSSL_VERSION3}/' b
 perl -i -pe 's/^\$OPENSSL_VERSION3\s*=.*$/\$OPENSSL_VERSION3 = "$ENV{OPENSSL_VERSION3}"/' build-mariadb-windows.ps1
 
 perl -i -pe 's/^OPENSSL_VERSION3=.*$/OPENSSL_VERSION3=$ENV{OPENSSL_VERSION3}/' build-mysql-darwin.sh
+perl -i -pe 's/^OPENSSL_VERSION3=.*$/OPENSSL_VERSION3=$ENV{OPENSSL_VERSION3}/' build-mysql-darwin-macos14.sh
 perl -i -pe 's/^OPENSSL_VERSION3=.*$/OPENSSL_VERSION3=$ENV{OPENSSL_VERSION3}/' build-mysql-linux.sh
 perl -i -pe 's/^\$OPENSSL_VERSION3\s*=.*$/\$OPENSSL_VERSION3 = "$ENV{OPENSSL_VERSION3}"/' build-mysql-windows.ps1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced compatibility for the build process with macOS 14 by defining OpenSSL version environment variables in new scripts.
  
- **Chores**
	- Updated shell scripts to improve build configuration without altering existing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->