### PR TITLE
fix MariaDB download URL.

### DIFF
--- a/.github/build-mariadb-darwin.sh
+++ b/.github/build-mariadb-darwin.sh
@@ -96,7 +96,7 @@ echo "::group::download MariaDB source"
 (
     set -eux
     cd "$RUNNER_TEMP"
-    curl --retry 3 -sSL "https://downloads.mariadb.com/MariaDB/mariadb-$MARIADB_VERSION/source/mariadb-$MARIADB_VERSION.tar.gz" -o mariadb-src.tar.gz
+    curl --retry 3 -sSL "https://github.com/MariaDB/server/archive/refs/tags/mariadb-$MARIADB_VERSION.tar.gz" -o mariadb-src.tar.gz
 )
 echo "::endgroup::"
 

--- a/.github/build-mariadb-linux.sh
+++ b/.github/build-mariadb-linux.sh
@@ -138,7 +138,7 @@ echo "::group::download MariaDB source"
 (
     set -eux
     cd "$RUNNER_TEMP"
-    curl --retry 3 -sSL "https://downloads.mariadb.com/MariaDB/mariadb-$MARIADB_VERSION/source/mariadb-$MARIADB_VERSION.tar.gz" -o mariadb-src.tar.gz
+    curl --retry 3 -sSL "https://github.com/MariaDB/server/archive/refs/tags/mariadb-$MARIADB_VERSION.tar.gz" -o mariadb-src.tar.gz
 )
 echo "::endgroup::"
 

--- a/.github/build-mariadb-windows.ps1
+++ b/.github/build-mariadb-windows.ps1
@@ -105,7 +105,7 @@ New-Item "$RUNNER_TEMP" -ItemType Directory -Force
 Write-Host "::group::fetch MariaDB source"
 Set-Location "$RUNNER_TEMP"
 Write-Host "Downloading zip archive..."
-Invoke-WebRequest "https://downloads.mariadb.com/MariaDB/mariadb-$MARIADB_VERSION/source/mariadb-$MARIADB_VERSION.tar.gz" -OutFile "mariadb-src.tar.gz"
+Invoke-WebRequest "https://github.com/MariaDB/server/archive/refs/tags/mariadb-$MARIADB_VERSION.tar.gz" -OutFile "mariadb-src.tar.gz"
 Write-Host "Untar..."
 tar zxvf mariadb-src.tar.gz
 Remove-Item -Path "mariadb-src.tar.gz"


### PR DESCRIPTION
I don't know why, but tarballs on https://downloads.mariadb.com/MariaDB/ are now available.
