### PR TITLE
MariaDB: disable ssl-verify-server-cert

### DIFF
--- a/src/starter.ts
+++ b/src/starter.ts
@@ -75,6 +75,11 @@ export async function startMySQL(
   config["client"]["port"] = config["mysqld"]["port"];
   config["client"]["host"] = "127.0.0.1";
   config["client"]["socket"] = config["mysqld"]["socket"];
+  // MariaDB 11.4 enables ssl-verify-server-cert by default.
+  // But our server cert and ca cert cause verify error when ssl-verify-server-cert or ssl-mode=VERIFY_CA.
+  // We need to disable server cert verification until we fix our CA & server certs.
+  config["client-mariadb"] ||= {};
+  config["client-mariadb"]["ssl-verify-server-cert"] = "0";
 
   await core.group("setup MySQL Database", async () => {
     core.info(`creating the directory structure on ${baseDir}`);

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -24,13 +24,6 @@ if ($distribution eq 'mysql') {
 } elsif ($distribution eq 'mariadb') {
     $command = qv($version) lt "10.5.0" ? 'mysql' : 'mariadb';
     @ssl_options = ('--ssl');
-
-    if (qv($version) ge "11.4.0") {
-        # I can't why, but MariaDB 11.4.0 fails
-        # to connect with `--ssl-verify-server-cert` option.
-        # So, I need to disable it.
-        @ssl_options = ('--ssl', '--disable-ssl-verify-server-cert');
-    }
 }
 
 subtest 'connect 127.0.0.1' => sub {


### PR DESCRIPTION
I don't know why, but current certs are not good enough for verification.

With mysql, `--ssl-mode=VERIFY_CA` and `--ssl-mode=VERIFY_IDENTITY` fail. (error message: `ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed`).

With mariadb, `--ssl-verify-server-cert` fails. (see #1136)

Since MariaDB 11.4, it enables ssl and ssl-verify-server-cert by default because they can verify self-signed server cert. ([ref](https://mariadb.org/mission-impossible-zero-configuration-ssl/)) But our server cert is not self-signed.

I can not fix certs. So I add an option to disable ssl-verify-server-cert for mariadb.

Fix #1136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL configuration for MariaDB, allowing for smoother database connections.
  
- **Bug Fixes**
	- Removed conditional logic that previously disabled SSL certificate verification for MariaDB versions 11.4.0 and above, ensuring better security practices.

- **Tests**
	- Updated test cases to reflect changes in SSL connection handling without altering the overall test structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->