### PR TITLE
fix generating ca.pem

### DIFF
--- a/src/starter.ts
+++ b/src/starter.ts
@@ -145,6 +145,8 @@ export async function startMySQL(
     config["mysqld"]["ssl_ca"] ||= path.join(baseDir, "var", "ca.pem");
     config["mysqld"]["ssl_cert"] ||= path.join(baseDir, "var", "server-cert.pem");
     config["mysqld"]["ssl_key"] ||= path.join(baseDir, "var", "server-key.pem");
+    config["client"] ||= {};
+    config["client"]["ssl_ca"] ||= path.join(baseDir, "var", "ca.pem");
 
     // configure my.cnf
     core.info(`add TLS/SSL setting into my.cnf`);
@@ -368,6 +370,8 @@ async function setupTls(mysql: installer.MySQL, baseDir: string): Promise<void> 
       "-req",
       "-in",
       `${datadir}${sep}ca-req.pem`,
+      "-extfile",
+      `${__dirname}${sep}..${sep}v3_ca.txt`,
       "-days",
       "3650",
       "-set_serial",

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -17,20 +17,13 @@ my @ssl_options;
 if ($distribution eq 'mysql') {
     if (qv($version) ge "5.7.0") {
         # --ssl-mode is available from MySQL 5.7
-        @ssl_options = ('--ssl-mode=REQUIRED');
+        @ssl_options = ('--ssl-mode=VERIFY_IDENTITY', "--ssl-ca=$capath");
     } else {
         @ssl_options = ('--ssl', "--ssl-ca=$capath");
     }
 } elsif ($distribution eq 'mariadb') {
     $command = qv($version) lt "10.5.0" ? 'mysql' : 'mariadb';
-    @ssl_options = ('--ssl');
-
-    if (qv($version) ge "11.4.0") {
-        # I can't why, but MariaDB 11.4.0 fails
-        # to connect with `--ssl-verify-server-cert` option.
-        # So, I need to disable it.
-        @ssl_options = ('--ssl', '--disable-ssl-verify-server-cert');
-    }
+    @ssl_options = ('--ssl', "--ssl-ca=$capath");
 }
 
 subtest 'connect 127.0.0.1' => sub {

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -7,23 +7,19 @@ use Util qw(run detect_version);
 use File::Spec;
 use version qw(qv);
 
-my $basedir = $ENV{BASE_DIR};
-die 'base-dir is not set' unless $basedir;
-my $capath = File::Spec->catfile($basedir, 'var', 'ca.pem');
-
 my ($version, $distribution) = detect_version('root', 'very-very-secret');
 my $command = 'mysql';
 my @ssl_options;
 if ($distribution eq 'mysql') {
     if (qv($version) ge "5.7.0") {
         # --ssl-mode is available from MySQL 5.7
-        @ssl_options = ('--ssl-mode=VERIFY_IDENTITY', "--ssl-ca=$capath");
+        @ssl_options = ('--ssl-mode=VERIFY_IDENTITY');
     } else {
-        @ssl_options = ('--ssl', "--ssl-ca=$capath");
+        @ssl_options = ('--ssl', '--ssl-verify-server-cert');
     }
 } elsif ($distribution eq 'mariadb') {
     $command = qv($version) lt "10.5.0" ? 'mysql' : 'mariadb';
-    @ssl_options = ('--ssl', "--ssl-ca=$capath");
+    @ssl_options = ('--ssl', '--ssl-verify-server-cert');
 }
 
 subtest 'connect 127.0.0.1' => sub {

--- a/v3_ca.txt
+++ b/v3_ca.txt
@@ -1,0 +1,1 @@
+basicConstraints = CA:true


### PR DESCRIPTION
ca.pem didn't include `CA:TRUE` constraint. So mysql/mariadb client can not verify CA.

This PR fix it, add `ssl_ca=` in the `[client]` section, and test `mysql --ssl-mode=VERIFY_IDENTITY` and `mariadb --ssl-verify-server-cert`.

Fix #1136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced MySQL configuration with TLS/SSL options for secure connections.
	- Introduced a new configuration file to define CA certificate constraints.

- **Bug Fixes**
	- Updated SSL connection commands for MySQL and MariaDB to improve security and compatibility.

- **Documentation**
	- Added necessary configuration details for CA certificates to ensure proper setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->