### PR TITLE
drop support of macos-12

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -68,7 +68,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-x64:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -69,7 +69,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-darwin-x64:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
           - ubuntu-24.04
           - ubuntu-22.04
           - ubuntu-20.04
+          - macos-15
           - macos-14
           - macos-13
-          - macos-12
           - windows-2022
           - windows-2019
         mysql:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the build workflows for MariaDB and MySQL to support newer macOS environments.
	- Introduced a new job for building MySQL on ARM architecture.
	- Expanded the testing environment to include macOS 15 and added Perl setup for testing.

- **Bug Fixes**
	- Enhanced dynamic selection of build runners based on MySQL versions.

- **Chores**
	- Standardized artifact naming conventions across build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->