### PR TITLE
remove LLVM installation for MySQL versions 8.4 and later in build script

### DIFF
--- a/.github/build-mysql-darwin.sh
+++ b/.github/build-mysql-darwin.sh
@@ -24,17 +24,6 @@ esac
 PREFIX=$RUNNER_TOOL_CACHE/mysql/$MYSQL_VERSION/$MYSQL_ARCH
 export LDFLAGS=-Wl,-rpath,$PREFIX/lib
 
-if [[ "$MYSQL_VERSION" =~ ^([1-9][0-9][.]|9[.]|8[.]4[.]) ]]; then # MySQL 8.4 or later
-    # install LLVM
-    brew install llvm@17
-    LLVM_PATH=$(brew --prefix llvm@17)
-    export PATH="$LLVM_PATH/bin:$PATH"
-    export LDFLAGS="$LDFLAGS -L$LLVM_PATH/lib"
-    export CPPFLAGS="$CPPFLAGS -I$LLVM_PATH/include"
-    export CC=$LLVM_PATH/bin/clang
-    export CXX=$LLVM_PATH/bin/clang++
-fi
-
 # detect the number of CPU Core
 JOBS=$(sysctl -n hw.logicalcpu_max)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the build script by removing the LLVM installation logic for MySQL versions 8.4 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->