### PR TITLE
download boost from another mirror

### DIFF
--- a/patches/mysql/8.1.0/download-boost-from-mirror.patch
+++ b/patches/mysql/8.1.0/download-boost-from-mirror.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/boost.cmake b/cmake/boost.cmake
+index c979055cf46..30eaa8534c9 100644
+--- a/cmake/boost.cmake
++++ b/cmake/boost.cmake
+@@ -41,7 +41,7 @@
+ SET(BOOST_PACKAGE_NAME "boost_1_77_0")
+ SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.bz2")
+ SET(BOOST_DOWNLOAD_URL
+-  "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
++  "https://github.com/shogo82148/boost-mirror/releases/download/1.77.0/${BOOST_TARBALL}"
+   )
+ 
+ SET(OLD_PACKAGE_NAMES

--- a/patches/mysql/8.2.0/download-boost-from-mirror.patch
+++ b/patches/mysql/8.2.0/download-boost-from-mirror.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/boost.cmake b/cmake/boost.cmake
+index c979055cf46..30eaa8534c9 100644
+--- a/cmake/boost.cmake
++++ b/cmake/boost.cmake
+@@ -41,7 +41,7 @@
+ SET(BOOST_PACKAGE_NAME "boost_1_77_0")
+ SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.bz2")
+ SET(BOOST_DOWNLOAD_URL
+-  "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
++  "https://github.com/shogo82148/boost-mirror/releases/download/1.77.0/${BOOST_TARBALL}"
+   )
+ 
+ SET(OLD_PACKAGE_NAMES


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
	- Updated Boost library download URL for MySQL versions 8.1.0 and 8.2.0
	- Migrated Boost library download source from JFrog Artifactory to GitHub mirror
	- Ensures continued accessibility of Boost library version 1.77.0 during build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->