### PR TITLE
Fix: Add missing #include <chrono> for std::chrono::duration_cast usage

### DIFF
--- a/patches/mysql/8.1.0/include-chrono.patch
+++ b/patches/mysql/8.1.0/include-chrono.patch
@@ -1,0 +1,27 @@
+From 0a0b9f76748f91ed408b414f69a4951c61212efd Mon Sep 17 00:00:00 2001
+From: Tor Didriksen <tor.didriksen@oracle.com>
+Date: Wed, 27 Nov 2024 12:46:07 +0100
+Subject: [PATCH] Bug#37329617 Include <chrono> for system_clock
+
+Add missing #include <chrono> for usage of std::chrono::duration_cast
+
+Change-Id: I26f487ce29f4ddce036ed67cc69fd236426d1905
+---
+ .../libmysqlgcs/src/bindings/xcom/xcom/task.cc                | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+index 8ef5f3c4f3dc..a21d5434e4b0 100644
+--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
++++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+@@ -75,6 +75,10 @@
+ 
+ #include <memory>
+ 
++#ifdef _WIN32
++#include <chrono>
++#endif
++
+ #include "xcom/node_connection.h"
+ #include "xdr_gen/xcom_vp.h"
+ 

--- a/patches/mysql/8.2.0/include-chrono.patch
+++ b/patches/mysql/8.2.0/include-chrono.patch
@@ -1,0 +1,27 @@
+From 0a0b9f76748f91ed408b414f69a4951c61212efd Mon Sep 17 00:00:00 2001
+From: Tor Didriksen <tor.didriksen@oracle.com>
+Date: Wed, 27 Nov 2024 12:46:07 +0100
+Subject: [PATCH] Bug#37329617 Include <chrono> for system_clock
+
+Add missing #include <chrono> for usage of std::chrono::duration_cast
+
+Change-Id: I26f487ce29f4ddce036ed67cc69fd236426d1905
+---
+ .../libmysqlgcs/src/bindings/xcom/xcom/task.cc                | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+index 8ef5f3c4f3dc..a21d5434e4b0 100644
+--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
++++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+@@ -75,6 +75,10 @@
+ 
+ #include <memory>
+ 
++#ifdef _WIN32
++#include <chrono>
++#endif
++
+ #include "xcom/node_connection.h"
+ #include "xdr_gen/xcom_vp.h"
+ 

--- a/patches/mysql/8.3.0/include-chrono.patch
+++ b/patches/mysql/8.3.0/include-chrono.patch
@@ -1,0 +1,27 @@
+From 0a0b9f76748f91ed408b414f69a4951c61212efd Mon Sep 17 00:00:00 2001
+From: Tor Didriksen <tor.didriksen@oracle.com>
+Date: Wed, 27 Nov 2024 12:46:07 +0100
+Subject: [PATCH] Bug#37329617 Include <chrono> for system_clock
+
+Add missing #include <chrono> for usage of std::chrono::duration_cast
+
+Change-Id: I26f487ce29f4ddce036ed67cc69fd236426d1905
+---
+ .../libmysqlgcs/src/bindings/xcom/xcom/task.cc                | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+index 8ef5f3c4f3dc..a21d5434e4b0 100644
+--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
++++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+@@ -75,6 +75,10 @@
+ 
+ #include <memory>
+ 
++#ifdef _WIN32
++#include <chrono>
++#endif
++
+ #include "xcom/node_connection.h"
+ #include "xdr_gen/xcom_vp.h"
+ 

--- a/patches/mysql/9.0.1/include-chrono.patch
+++ b/patches/mysql/9.0.1/include-chrono.patch
@@ -1,0 +1,27 @@
+From 0a0b9f76748f91ed408b414f69a4951c61212efd Mon Sep 17 00:00:00 2001
+From: Tor Didriksen <tor.didriksen@oracle.com>
+Date: Wed, 27 Nov 2024 12:46:07 +0100
+Subject: [PATCH] Bug#37329617 Include <chrono> for system_clock
+
+Add missing #include <chrono> for usage of std::chrono::duration_cast
+
+Change-Id: I26f487ce29f4ddce036ed67cc69fd236426d1905
+---
+ .../libmysqlgcs/src/bindings/xcom/xcom/task.cc                | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+index 8ef5f3c4f3dc..a21d5434e4b0 100644
+--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
++++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+@@ -75,6 +75,10 @@
+ 
+ #include <memory>
+ 
++#ifdef _WIN32
++#include <chrono>
++#endif
++
+ #include "xcom/node_connection.h"
+ #include "xdr_gen/xcom_vp.h"
+ 

--- a/patches/mysql/9.1.0/include-chrono.patch
+++ b/patches/mysql/9.1.0/include-chrono.patch
@@ -1,0 +1,27 @@
+From 0a0b9f76748f91ed408b414f69a4951c61212efd Mon Sep 17 00:00:00 2001
+From: Tor Didriksen <tor.didriksen@oracle.com>
+Date: Wed, 27 Nov 2024 12:46:07 +0100
+Subject: [PATCH] Bug#37329617 Include <chrono> for system_clock
+
+Add missing #include <chrono> for usage of std::chrono::duration_cast
+
+Change-Id: I26f487ce29f4ddce036ed67cc69fd236426d1905
+---
+ .../libmysqlgcs/src/bindings/xcom/xcom/task.cc                | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+index 8ef5f3c4f3dc..a21d5434e4b0 100644
+--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
++++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/task.cc
+@@ -75,6 +75,10 @@
+ 
+ #include <memory>
+ 
++#ifdef _WIN32
++#include <chrono>
++#endif
++
+ #include "xcom/node_connection.h"
+ #include "xdr_gen/xcom_vp.h"
+ 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Windows compatibility by ensuring reliable handling of time-based operations, enhancing overall stability for users on Windows platforms. These behind-the-scenes updates improve the consistency of time duration functionality without impacting publicly visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->