### PR TITLE
drop support of Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -31,7 +31,7 @@ jobs:
             export MARIADB_VERSIONS
           fi
           {
-            echo "matrix-linux=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: . , os: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-20.04", "ubuntu-24.04-arm", "ubuntu-22.04-arm"]}')"
+            echo "matrix-linux=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: . , os: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-22.04-arm"]}')"
             echo "matrix-darwin=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')"
             echo "matrix-windows=$(printenv MARIADB_VERSIONS | jq -c '{mariadb: .}')"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -32,7 +32,7 @@ jobs:
             export MYSQL_VERSIONS
           fi
           {
-            echo "matrix-linux=$(printenv MYSQL_VERSIONS | jq -c '{mysql: . , os: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-20.04", "ubuntu-24.04-arm", "ubuntu-22.04-arm"]}')"
+            echo "matrix-linux=$(printenv MYSQL_VERSIONS | jq -c '{mysql: . , os: ["ubuntu-24.04", "ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-22.04-arm"]}')"
             echo "matrix-darwin=$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')"
             echo "matrix-windows=$(printenv MYSQL_VERSIONS | jq -c '{mysql: .}')"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration build configurations to streamline Linux builds. The build matrix now targets Ubuntu 22.04 and Ubuntu 24.04 (including ARM variants), removing older configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->