### PR TITLE
windows-2019 is no longer available

### DIFF
--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -137,7 +137,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-windows:
-    runs-on: ${{ startsWith(matrix.mysql, '5.') && 'windows-2019' || 'windows-2022' }}
+    runs-on: "windows-2022"
     needs: list
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,6 @@ jobs:
           - macos-13
           - windows-2025
           - windows-2022
-          - windows-2019
         mysql:
           - "9.2"
           - "8.4" # LTS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to use only the Windows 2022 runner for all MySQL build jobs.
  * Removed Windows 2019 from the list of operating systems used in automated test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->