### PR TITLE
add macos-26 into the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04-arm
           - ubuntu-22.04-arm
+          - macos-26
           - macos-15
           - macos-14
           - macos-13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded continuous integration test matrix to include an additional macOS environment, improving cross-platform coverage and reliability of builds on Apple devices.
  - Enhances detection of platform-specific issues earlier in the pipeline, reducing risk of regressions.
  - No changes to app behavior or features; this update is infrastructure-only and does not alter the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->